### PR TITLE
Fixed flakey tests that were testing length validation

### DIFF
--- a/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/MethodValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/MethodValidatorTest.java
@@ -120,7 +120,7 @@ public class MethodValidatorTest {
 	public void testWithNameLengthExceedMaxLimit() throws MiddlewareException {
 
 		MethodDetails methodDetails = TestDataProvider.getTestMethodDetails();
-		methodDetails.setName(RandomStringUtils.random(201));
+		methodDetails.setName(RandomStringUtils.randomAlphanumeric(201));
 
 		BindingResult bindingResult = new MapBindingResult(new HashMap<String, String>(), "Method");
 
@@ -136,7 +136,7 @@ public class MethodValidatorTest {
 	public void testWithDescriptionLengthExceedMaxLimit() throws MiddlewareException {
 
 		MethodDetails methodSummary = TestDataProvider.getTestMethodDetails();
-		methodSummary.setDescription(RandomStringUtils.random(1025));
+		methodSummary.setDescription(RandomStringUtils.randomAlphanumeric(1025));
 
 		Mockito.doReturn(null).when(this.termDataManager).getTermByNameAndCvId(methodSummary.getName(), CvId.METHODS.getId());
 
@@ -168,7 +168,7 @@ public class MethodValidatorTest {
 
 	/**
 	 * Test for to check Method is Editable or Not
-	 * 
+	 *
 	 * @throws MiddlewareException
 	 */
 	@Test

--- a/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/PropertyValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/PropertyValidatorTest.java
@@ -147,7 +147,7 @@ public class PropertyValidatorTest {
 	public void testWithNameLengthExceedMaxLimit() throws MiddlewareException {
 
 		PropertyDetails propertyDetails = TestDataProvider.getTestPropertyDetails();
-		propertyDetails.setName(RandomStringUtils.random(205));
+		propertyDetails.setName(RandomStringUtils.randomAlphanumeric(205));
 
 		BindingResult bindingResult = new MapBindingResult(new HashMap<String, String>(), "Property");
 
@@ -165,7 +165,7 @@ public class PropertyValidatorTest {
 	public void testWithDescriptionLengthExceedMaxLimit() throws MiddlewareException {
 
 		PropertyDetails propertyDetails = TestDataProvider.getTestPropertyDetails();
-		propertyDetails.setDescription(RandomStringUtils.random(1025));
+		propertyDetails.setDescription(RandomStringUtils.randomAlphanumeric(1025));
 
 		Mockito.doReturn(null).when(this.termDataManager).getTermByNameAndCvId(propertyDetails.getName(), CvId.PROPERTIES.getId());
 

--- a/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/ScaleValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/ScaleValidatorTest.java
@@ -188,7 +188,7 @@ public class ScaleValidatorTest {
 
 		List<TermSummary> categories = new ArrayList<>();
 		TermSummary category = new TermSummary();
-		category.setName(RandomStringUtils.random(205));
+		category.setName(RandomStringUtils.randomAlphanumeric(205));
 		category.setDescription("description");
 		categories.add(category);
 		scaleSummary.setCategories(categories);
@@ -211,7 +211,7 @@ public class ScaleValidatorTest {
 		List<TermSummary> categories = new ArrayList<>();
 		TermSummary category = new TermSummary();
 		category.setName("Name");
-		category.setDescription(RandomStringUtils.random(260));
+		category.setDescription(RandomStringUtils.randomAlphanumeric(256));
 		categories.add(category);
 		scaleSummary.setCategories(categories);
 
@@ -246,7 +246,7 @@ public class ScaleValidatorTest {
 	public void testWithNameLengthExceedMaxLimit() throws MiddlewareException {
 
 		ScaleDetails scaleSummary = TestDataProvider.getTestScaleDetails();
-		scaleSummary.setName(RandomStringUtils.random(205));
+		scaleSummary.setName(RandomStringUtils.randomAlphanumeric(205));
 		Mockito.doReturn(null).when(this.termDataManager).getTermByNameAndCvId(scaleSummary.getName(), CvId.SCALES.getId());
 
 		BindingResult bindingResult = new MapBindingResult(new HashMap<String, String>(), "Scale");
@@ -265,7 +265,7 @@ public class ScaleValidatorTest {
 	public void testWithDescriptionLengthExceedMaxLimit() throws MiddlewareException {
 
 		ScaleDetails scaleSummary = TestDataProvider.getTestScaleDetails();
-		scaleSummary.setDescription(RandomStringUtils.random(1025));
+		scaleSummary.setDescription(RandomStringUtils.randomAlphanumeric(1025));
 
 		Mockito.doReturn(null).when(this.termDataManager).getTermByNameAndCvId(scaleSummary.getName(), CvId.SCALES.getId());
 

--- a/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/VariableValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/ontology/validator/VariableValidatorTest.java
@@ -105,7 +105,7 @@ public class VariableValidatorTest {
 
 		VariableDetails variable = TestDataProvider.getTestVariableDetails();
 		variable.setId(null);
-		variable.setName(RandomStringUtils.random(201));
+		variable.setName(RandomStringUtils.randomAlphanumeric(201));
 
 		Term methodTerm = TestDataProvider.getMethodTerm();
 		Term propertyTerm = TestDataProvider.getPropertyTerm();
@@ -138,7 +138,7 @@ public class VariableValidatorTest {
 
 		VariableDetails variable = TestDataProvider.getTestVariableDetails();
 		variable.setId(null);
-		variable.setDescription(RandomStringUtils.random(1025));
+		variable.setDescription(RandomStringUtils.randomAlphanumeric(1025));
 
 		Term methodTerm = TestDataProvider.getMethodTerm();
 		Term propertyTerm = TestDataProvider.getPropertyTerm();


### PR DESCRIPTION
The random string that was being validated in these tests could contain whitespace at the start/end and is being trimmed before validation.

This means that if a string had whitespace at the start/end the test would fail as it assumed there to be no whitespace. To solve this we ensure that the string being checked cannot be trimmed shorter, thus it will trigger the validation error.

Issue: BMS-36
Reviewer: Iryna
