### PR TITLE
BMS-2724 Updating our JTA properties to be more consistent

### DIFF
--- a/src/main/resources/jta.properties
+++ b/src/main/resources/jta.properties
@@ -4,4 +4,5 @@ com.atomikos.icatch.log_base_dir=${jta.log.directory}/bmsapi/transactions/
 com.atomikos.icatch.service=com.atomikos.icatch.standalone.UserTransactionServiceFactory
 com.atomikos.icatch.serial_jta_transactions=false
 com.atomikos.icatch.max_actives=-1
-com.atomikos.icatch.max_timeout=500000
+com.atomikos.icatch.max_timeout=300000
+com.atomikos.icatch.default_jta_timeout=300000


### PR DESCRIPTION
We have updated the max JTA transaction timeout and max default timeout to the same value.

We have chosen 5 minutes as operations requiring longer need to be coded as a batch process.

issue: BMS-2724
reviewer: MatthewB
