### PR TITLE
BMS-3078 Fixing label creation for large lists in Nursery Manager

### DIFF
--- a/src/main/java/org/ibp/api/java/impl/middleware/study/FieldMapService.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/study/FieldMapService.java
@@ -233,7 +233,7 @@ public class FieldMapService {
 
 			final List<FieldMapInfo> fieldMapInfoOfStudy =
 					this.studyDataManager.getFieldMapInfoOfStudy(Lists.newArrayList(studyIdentifier), studyType,
-							crossExpansionProperties, true);
+							crossExpansionProperties);
 			return new StudyFieldMap(studyType, fieldMapInfoOfStudy);
 		} catch (MiddlewareQueryException e) {
 			throw new ApiRuntimeException(String.format("There was an error retriving infomration for studyId %s was found.", studyId), e);

--- a/src/test/java/org/ibp/api/java/impl/middleware/study/ComplexFieldMapServiceTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/study/ComplexFieldMapServiceTest.java
@@ -34,7 +34,7 @@ public class ComplexFieldMapServiceTest {
 		when(studyDataManager.getStudyType(123)).thenReturn(StudyType.T);
 		when(
 				studyDataManager.getFieldMapInfoOfStudy(Matchers.<List<Integer>>any(), any(StudyType.class),
-						any(CrossExpansionProperties.class), Matchers.anyBoolean())).thenReturn(testFieldMapInfo);
+						any(CrossExpansionProperties.class))).thenReturn(testFieldMapInfo);
 		FieldMapService fieldMapService = new FieldMapService(studyDataManager, Mockito.mock(CrossExpansionProperties.class));
 		simpleFieldMap = fieldMapService.getFieldMap("123");
 	}

--- a/src/test/java/org/ibp/api/java/impl/middleware/study/FieldMapServiceTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/study/FieldMapServiceTest.java
@@ -42,7 +42,7 @@ public class FieldMapServiceTest {
 		when(studyDataManager.getStudyType(123)).thenReturn(StudyType.T);
 		when(
 				studyDataManager.getFieldMapInfoOfStudy(Matchers.<List<Integer>>any(), any(StudyType.class),
-						any(CrossExpansionProperties.class), Matchers.anyBoolean())).thenReturn(testFieldMapInfo);
+						any(CrossExpansionProperties.class))).thenReturn(testFieldMapInfo);
 		FieldMapService fieldMapService = new FieldMapService(studyDataManager, Mockito.mock(CrossExpansionProperties.class));
 		simpleFieldMap = fieldMapService.getFieldMap("123");
 	}


### PR DESCRIPTION
Issue: [BMS-3078](https://leafnode.atlassian.net/browse/BMS-3078)
Removing last param from getFieldMapInfoOfStudy and fixing tests

Related PRs:
https://github.com/IntegratedBreedingPlatform/Middleware/pull/212
https://github.com/IntegratedBreedingPlatform/Fieldbook/pull/366
