### PR TITLE
BMS-3587 BMS-3535 variable cache per program and variable cache controllers

### DIFF
--- a/src/main/java/org/ibp/api/java/impl/middleware/ontology/VariableServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/ontology/VariableServiceImpl.java
@@ -72,11 +72,11 @@ public class VariableServiceImpl extends ServiceBaseImpl implements VariableServ
 
 		this.programValidator.validate(program, bindingResult);
 
-		setCurrentProgram(programId);
-
 		if (bindingResult.hasErrors()) {
 			throw new ApiRequestValidationException(bindingResult.getAllErrors());
 		}
+
+		setCurrentProgram(programId);
 
 		if (!Strings.isNullOrEmpty(propertyId)) {
 			this.validateId(propertyId, VariableServiceImpl.VARIABLE_NAME);
@@ -119,11 +119,11 @@ public class VariableServiceImpl extends ServiceBaseImpl implements VariableServ
 
 		this.programValidator.validate(program, bindingResult);
 
-		setCurrentProgram(programId);
-
 		if (bindingResult.hasErrors()) {
 			throw new ApiRequestValidationException(bindingResult.getAllErrors());
 		}
+
+		setCurrentProgram(programId);
 
 		try {
 
@@ -159,11 +159,11 @@ public class VariableServiceImpl extends ServiceBaseImpl implements VariableServ
 
 		this.programValidator.validate(program, errors);
 
-		setCurrentProgram(programId);
-
 		if (errors.hasErrors()) {
 			throw new ApiRequestValidationException(errors.getAllErrors());
 		}
+
+		setCurrentProgram(programId);
 
 		TermRequest term = new TermRequest(variableId, VariableServiceImpl.VARIABLE_NAME, CvId.VARIABLES.getId());
 		this.termValidator.validate(term, errors);
@@ -362,7 +362,21 @@ public class VariableServiceImpl extends ServiceBaseImpl implements VariableServ
 	}
 
 	@Override
-	public void deleteVariablesFromCache(final String cropname, final Integer[] variablesIds) {
+	public void deleteVariablesFromCache(final String cropName, final Integer[] variablesIds, String programId) {
+
+		BindingResult bindingResult = new MapBindingResult(new HashMap<String, String>(), VariableServiceImpl.VARIABLE_NAME);
+
+		ProgramSummary program = new ProgramSummary();
+		program.setCrop(cropName);
+		program.setUniqueID(programId);
+
+		this.programValidator.validate(program, bindingResult);
+
+		if (bindingResult.hasErrors()) {
+			throw new ApiRequestValidationException(bindingResult.getAllErrors());
+		}
+
+		setCurrentProgram(programId);
 
 		for (final Integer variableId : variablesIds) {
 			this.validateId(String.valueOf(variableId), VariableServiceImpl.VARIABLE_NAME);

--- a/src/main/java/org/ibp/api/java/ontology/VariableService.java
+++ b/src/main/java/org/ibp/api/java/ontology/VariableService.java
@@ -70,6 +70,7 @@ public interface VariableService {
 	 * Remove variable from cache
 	 * @param cropname name of the crop
 	 * @param variablesIds array of ids to remove
+	 * @param programId program unique id
 	 */
-	void deleteVariablesFromCache(String cropname, final Integer[] variablesIds);
+	void deleteVariablesFromCache(String cropname, final Integer[] variablesIds, String programId);
 }

--- a/src/main/java/org/ibp/controller/VariableCacheController.java
+++ b/src/main/java/org/ibp/controller/VariableCacheController.java
@@ -1,3 +1,4 @@
+
 package org.ibp.controller;
 
 import org.ibp.api.java.ontology.VariableService;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.wordnik.swagger.annotations.Api;
@@ -27,8 +29,9 @@ public class VariableCacheController {
 	@RequestMapping(value = "/{cropName}/{variablesIds}", method = RequestMethod.DELETE)
 	public ResponseEntity<String> deleteVariablesFromCache(
 			@ApiParam(value = "name of the crop", required = true) @PathVariable final String cropName,
-			@ApiParam(value = "Comma separated list of variable ids", required = true) @PathVariable final Integer[] variablesIds) {
-		this.variableService.deleteVariablesFromCache(cropName, variablesIds);
+			@ApiParam(value = "Comma separated list of variable ids", required = true) @PathVariable final Integer[] variablesIds,
+			@RequestParam(value = "programId") String programId) {
+		this.variableService.deleteVariablesFromCache(cropName, variablesIds, programId);
 		return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 	}
 }


### PR DESCRIPTION
Please review

This PR contains Fix for BMS-3587 and BMS-3535. The later was incorporated into the former since code from it was needed and some modifications were needed in BMS-3535 too.

Other branches:
https://github.com/IntegratedBreedingPlatform/Workbench/pull/110
https://github.com/IntegratedBreedingPlatform/Middleware/pull/254
https://github.com/IntegratedBreedingPlatform/Fieldbook/pull/410
https://github.com/IntegratedBreedingPlatform/Commons/pull/111
https://github.com/IntegratedBreedingPlatform/BreedingManager/pull/197
