### PR TITLE
IBP-3706 IBP-3665 Fix performance of lot label printing

### DIFF
--- a/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/LotServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/LotServiceImpl.java
@@ -10,6 +10,7 @@ import org.generationcp.middleware.domain.inventory.manager.LotItemDto;
 import org.generationcp.middleware.domain.inventory.manager.LotSearchMetadata;
 import org.generationcp.middleware.domain.inventory.manager.LotUpdateRequestDto;
 import org.generationcp.middleware.domain.inventory.manager.LotsSearchDto;
+import org.generationcp.middleware.pojos.UserDefinedField;
 import org.generationcp.middleware.pojos.workbench.CropType;
 import org.generationcp.middleware.pojos.workbench.WorkbenchUser;
 import org.ibp.api.java.impl.middleware.inventory.manager.validator.LotImportRequestDtoValidator;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -57,6 +59,16 @@ public class LotServiceImpl implements LotService {
 	@Override
 	public long countSearchLots(final LotsSearchDto lotsSearchDto) {
 		return lotService.countSearchLots(lotsSearchDto);
+	}
+
+	@Override
+	public List<UserDefinedField> getGermplasmAttributeTypes(final LotsSearchDto searchDto) {
+		return this.lotService.getGermplasmAttributeTypes(searchDto);
+	}
+
+	@Override
+	public Map<Integer, Map<Integer, String>> getGermplasmAttributeValues(final LotsSearchDto searchDto) {
+		return this.lotService.getGermplasmAttributeValues(searchDto);
 	}
 
 	@Override

--- a/src/main/java/org/ibp/api/java/inventory/manager/LotService.java
+++ b/src/main/java/org/ibp/api/java/inventory/manager/LotService.java
@@ -6,15 +6,21 @@ import org.generationcp.middleware.domain.inventory.manager.LotImportRequestDto;
 import org.generationcp.middleware.domain.inventory.manager.LotSearchMetadata;
 import org.generationcp.middleware.domain.inventory.manager.LotUpdateRequestDto;
 import org.generationcp.middleware.domain.inventory.manager.LotsSearchDto;
+import org.generationcp.middleware.pojos.UserDefinedField;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
 
 public interface LotService {
 
 	List<ExtendedLotDto> searchLots(LotsSearchDto lotsSearchDto, Pageable pageable);
 
 	long countSearchLots(LotsSearchDto lotsSearchDto);
+
+	List<UserDefinedField> getGermplasmAttributeTypes(LotsSearchDto searchDto);
+
+	Map<Integer, Map<Integer, String>> getGermplasmAttributeValues(LotsSearchDto searchDto);
 
 	Integer saveLot(LotGeneratorInputDto lotGeneratorInputDto);
 

--- a/src/main/java/org/ibp/api/rest/labelprinting/LotLabelPrinting.java
+++ b/src/main/java/org/ibp/api/rest/labelprinting/LotLabelPrinting.java
@@ -1,6 +1,5 @@
 package org.ibp.api.rest.labelprinting;
 
-import com.google.common.collect.Lists;
 import org.generationcp.commons.util.DateUtil;
 import org.generationcp.commons.util.FileUtils;
 import org.generationcp.middleware.domain.inventory.manager.ExtendedLotDto;
@@ -30,7 +29,6 @@ import org.springframework.validation.ObjectError;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -211,8 +209,7 @@ public class LotLabelPrinting extends LabelPrintingStrategy {
 		final LotsSearchDto searchDto =
 			(LotsSearchDto) this.searchRequestService.getSearchRequest(searchRequestId, LotsSearchDto.class);
 		final List<ExtendedLotDto> extendedLotDtos = this.lotService.searchLots(searchDto, null);
-		final Set<Integer> gids = extendedLotDtos.stream().map(ExtendedLotDto::getGid).collect(Collectors.toSet());
-		final List<UserDefinedField> attributes = this.germplasmDataManager.getAttributeTypesByGIDList(Lists.newArrayList(gids));
+		final List<UserDefinedField> attributes = this.lotService.getGermplasmAttributeTypes(searchDto);
 
 		// Build label list
 
@@ -223,7 +220,7 @@ public class LotLabelPrinting extends LabelPrintingStrategy {
 		final LabelType germplasmLabelTypes = new LabelType(GERMPLASM_FIXED_LABEL_TYPES.getTitle(), GERMPLASM_FIXED_LABEL_TYPES.getKey());
 		germplasmLabelTypes.setFields(new ArrayList<>(GERMPLASM_FIXED_LABEL_TYPES.getFields()));
 		germplasmLabelTypes.getFields().addAll(attributes.stream()
-			.map(attr -> new Field(toKey(attr.getFldno()), attr.getFname()))
+			.map(attr -> new Field(toKey(attr.getFldno()), attr.getFcode()))
 			.collect(Collectors.toList()));
 		labelTypes.add(germplasmLabelTypes);
 
@@ -237,8 +234,7 @@ public class LotLabelPrinting extends LabelPrintingStrategy {
 		final LotsSearchDto searchDto =
 			(LotsSearchDto) this.searchRequestService.getSearchRequest(searchRequestId, LotsSearchDto.class);
 		final List<ExtendedLotDto> extendedLotDtos = this.lotService.searchLots(searchDto, null);
-		final Set<Integer> gids = extendedLotDtos.stream().map(ExtendedLotDto::getGid).collect(Collectors.toSet());
-		final Map<Integer, Map<Integer, String>> attributeValues = this.germplasmDataManager.getAttributeValuesGIDList(new ArrayList<>(gids));
+		final Map<Integer, Map<Integer, String>> attributeValues = this.lotService.getGermplasmAttributeValues(searchDto);
 
 		// Data to be exported
 		final List<Map<Integer, String>> data = new ArrayList<>();


### PR DESCRIPTION
- Instead of sending list of gids as parameter, take advantage of lot
query and lotSearch filters.
- Use fcode instead of fname