### PR TITLE
IBP-3700 Move amounts validation after status validation

### DIFF
--- a/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/TransactionUpdateRequestDtoValidator.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/TransactionUpdateRequestDtoValidator.java
@@ -49,12 +49,6 @@ public class TransactionUpdateRequestDtoValidator {
 			throw new ApiRequestValidationException(this.errors.getAllErrors());
 		}
 
-		final Predicate<TransactionUpdateRequestDto> isValid = i -> i.isValid();
-		if (transactionUpdateRequestDtos.stream().filter(isValid.negate()).count() > 0) {
-			errors.reject("transaction.update.invalid.data", "");
-			throw new ApiRequestValidationException(this.errors.getAllErrors());
-		}
-
 		final List<Integer> transactionIds =
 			transactionUpdateRequestDtos.stream().map(TransactionUpdateRequestDto::getTransactionId).collect(
 				Collectors.toList());
@@ -106,6 +100,12 @@ public class TransactionUpdateRequestDtoValidator {
 					transactionDtos.stream().filter(isWithdrawalOrDepositType.negate()).map(TransactionDto::getTransactionId).collect(
 						Collectors.toList()), 3)}, "");
 			throw new ApiRequestValidationException(errors.getAllErrors());
+		}
+
+		final Predicate<TransactionUpdateRequestDto> isValid = i -> i.isValid();
+		if (transactionUpdateRequestDtos.stream().filter(isValid.negate()).count() > 0) {
+			errors.reject("transaction.update.invalid.data", "");
+			throw new ApiRequestValidationException(this.errors.getAllErrors());
 		}
 
 		final long invalidAmountCount =

--- a/src/test/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/TransactionUpdateRequestDtoValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/TransactionUpdateRequestDtoValidatorTest.java
@@ -77,8 +77,31 @@ public class TransactionUpdateRequestDtoValidatorTest {
 	@Test
 	public void testValidateTransactionUpdateRequestDtoValidatorHasInvalidData() {
 		try {
+			this.transactionDtos.clear();
+
+			final TransactionDto transaction1 = new TransactionDto();
+			transaction1.setTransactionId(1);
+			final ExtendedLotDto lotDto1 = new ExtendedLotDto();
+			lotDto1.setLotId(1);
+			lotDto1.setStatus(LotStatus.ACTIVE.name());
+			transaction1.setLot(lotDto1);
+			transaction1.setTransactionStatus(TransactionStatus.PENDING.getValue());
+			transaction1.setTransactionType(TransactionType.DEPOSIT.getValue());
+			this.transactionDtos.add(transaction1);
+
+			final TransactionDto transaction2 = new TransactionDto();
+			transaction2.setTransactionId(2);
+			final ExtendedLotDto lotDto2 = new ExtendedLotDto();
+			lotDto2.setLotId(1);
+			lotDto2.setStatus(LotStatus.ACTIVE.name());
+			transaction2.setLot(lotDto2);
+			transaction2.setTransactionStatus(TransactionStatus.PENDING.getValue());
+			transaction2.setTransactionType(TransactionType.DEPOSIT.getValue());
+			this.transactionDtos.add(transaction2);
+
 			final List<TransactionUpdateRequestDto> transactionUpdateRequestDtoList = new ArrayList<>();
 			transactionUpdateRequestDtoList.add(new TransactionUpdateRequestDto(1, 2d, 2d, ""));
+			transactionUpdateRequestDtoList.add(new TransactionUpdateRequestDto(2, null, 2d, ""));
 			this.transactionUpdateRequestDtoValidator.validate(transactionUpdateRequestDtoList);
 		} catch (ApiRequestValidationException e) {
 			assertThat(Arrays.asList(e.getErrors().get(0).getCodes()), hasItem("transaction.update.invalid.data"));
@@ -127,7 +150,7 @@ public class TransactionUpdateRequestDtoValidatorTest {
 			this.transactionDtos.add(transaction1);
 
 			final TransactionDto transaction2 = new TransactionDto();
-			transaction2.setTransactionId(1);
+			transaction2.setTransactionId(2);
 			final ExtendedLotDto lotDto2 = new ExtendedLotDto();
 			lotDto2.setLotId(1);
 			lotDto2.setStatus(LotStatus.ACTIVE.name());
@@ -158,7 +181,7 @@ public class TransactionUpdateRequestDtoValidatorTest {
 			this.transactionDtos.add(transaction1);
 
 			final TransactionDto transaction2 = new TransactionDto();
-			transaction2.setTransactionId(1);
+			transaction2.setTransactionId(2);
 			final ExtendedLotDto lotDto2 = new ExtendedLotDto();
 			lotDto2.setLotId(1);
 			lotDto2.setStatus(LotStatus.ACTIVE.name());
@@ -191,7 +214,7 @@ public class TransactionUpdateRequestDtoValidatorTest {
 			this.transactionDtos.add(transaction1);
 
 			final TransactionDto transaction2 = new TransactionDto();
-			transaction2.setTransactionId(1);
+			transaction2.setTransactionId(2);
 			final ExtendedLotDto lotDto2 = new ExtendedLotDto();
 			lotDto2.setLotId(1);
 			lotDto2.setStatus(LotStatus.ACTIVE.name());
@@ -226,7 +249,7 @@ public class TransactionUpdateRequestDtoValidatorTest {
 			this.transactionDtos.add(transaction1);
 
 			final TransactionDto transaction2 = new TransactionDto();
-			transaction2.setTransactionId(1);
+			transaction2.setTransactionId(2);
 			final ExtendedLotDto lotDto2 = new ExtendedLotDto();
 			lotDto2.setLotId(1);
 			lotDto2.setStatus(LotStatus.ACTIVE.name());
@@ -261,7 +284,7 @@ public class TransactionUpdateRequestDtoValidatorTest {
 			this.transactionDtos.add(transaction1);
 
 			final TransactionDto transaction2 = new TransactionDto();
-			transaction2.setTransactionId(1);
+			transaction2.setTransactionId(2);
 			final ExtendedLotDto lotDto2 = new ExtendedLotDto();
 			lotDto2.setLotId(1);
 			lotDto2.setStatus(LotStatus.ACTIVE.name());
@@ -296,7 +319,7 @@ public class TransactionUpdateRequestDtoValidatorTest {
 			this.transactionDtos.add(transaction1);
 
 			final TransactionDto transaction2 = new TransactionDto();
-			transaction2.setTransactionId(1);
+			transaction2.setTransactionId(2);
 			transaction2.setLot(lotDto1);
 			transaction2.setTransactionStatus(TransactionStatus.PENDING.getValue());
 			transaction2.setTransactionType(TransactionType.DEPOSIT.getValue());
@@ -328,7 +351,7 @@ public class TransactionUpdateRequestDtoValidatorTest {
 			this.transactionDtos.add(transaction1);
 
 			final TransactionDto transaction2 = new TransactionDto();
-			transaction2.setTransactionId(1);
+			transaction2.setTransactionId(2);
 			final ExtendedLotDto lotDto2 = new ExtendedLotDto();
 			lotDto2.setLotId(1);
 			lotDto2.setStatus(LotStatus.ACTIVE.name());


### PR DESCRIPTION
This way the status validation will come before making it more clear to
the user that it's not possible to update transactions with status <>
pending
