### PR TITLE
IBP-3901 If available, use OAuth token, if not use X-Auth-Token

### DIFF
--- a/src/main/java/org/ibp/api/exception/DefaultExceptionHandler.java
+++ b/src/main/java/org/ibp/api/exception/DefaultExceptionHandler.java
@@ -61,7 +61,7 @@ public class DefaultExceptionHandler {
 	@ExceptionHandler(AccessDeniedException.class)
 	@ResponseStatus(value = FORBIDDEN)
 	@ResponseBody
-	public ErrorResponse handleUncaughtException(AccessDeniedException ex) {
+	public ErrorResponse handleAccessDeniedException(AccessDeniedException ex) {
 		LOG.error("Access Denied", ex);
 		ErrorResponse response = new ErrorResponse();
 		response.addError(getMessage("access.denied", null));

--- a/src/main/java/org/ibp/api/security/xauth/XAuthTokenFilter.java
+++ b/src/main/java/org/ibp/api/security/xauth/XAuthTokenFilter.java
@@ -30,9 +30,9 @@ public class XAuthTokenFilter extends GenericFilterBean {
 
 	final static String XAUTH_TOKEN_HEADER_NAME = "x-auth-token";
 
-	// BrAPI
-	final static String AUTH_TOKEN_HEADER_NAME = "Authorization";
-	final static String BEARER_PREFIX = "Bearer ";
+	// OAuth / BrAPI
+	final static String OAUTH_TOKEN_HEADER_NAME = "Authorization";
+	final static String OAUTH_TOKEN_PREFIX = "Bearer ";
 
 	private final UserDetailsService detailsService;
 
@@ -54,12 +54,12 @@ public class XAuthTokenFilter extends GenericFilterBean {
 
 			String authToken = null;
 
-			if (httpServletRequest.getRequestURI().contains("/brapi")) {
-				final String tokenHeader = httpServletRequest.getHeader(XAuthTokenFilter.AUTH_TOKEN_HEADER_NAME);
-				if (tokenHeader != null) {
-					authToken = tokenHeader.substring(BEARER_PREFIX.length());
-				}
-			} else {
+			final String tokenHeader = httpServletRequest.getHeader(XAuthTokenFilter.OAUTH_TOKEN_HEADER_NAME);
+			if (tokenHeader != null) {
+				authToken = tokenHeader.substring(OAUTH_TOKEN_PREFIX.length());
+			}
+
+			if (authToken == null) {
 				authToken = httpServletRequest.getHeader(XAuthTokenFilter.XAUTH_TOKEN_HEADER_NAME);
 			}
 

--- a/src/test/java/org/ibp/api/security/xauth/XAuthTokenFilterTest.java
+++ b/src/test/java/org/ibp/api/security/xauth/XAuthTokenFilterTest.java
@@ -81,8 +81,7 @@ public class XAuthTokenFilterTest {
 		final MockHttpServletResponse response = new MockHttpServletResponse();
 		final MockFilterChain filterChain = new MockFilterChain();
 
-		request.setRequestURI("/brapi");
-		request.addHeader(XAuthTokenFilter.AUTH_TOKEN_HEADER_NAME, XAuthTokenFilter.BEARER_PREFIX + token.getToken());
+		request.addHeader(XAuthTokenFilter.OAUTH_TOKEN_HEADER_NAME, XAuthTokenFilter.OAUTH_TOKEN_PREFIX + token.getToken());
 
 		final XAuthTokenFilter filter = new XAuthTokenFilter(this.userDetailsService, this.tokenProvider);
 		filter.doFilter(request, response, filterChain);
@@ -120,8 +119,7 @@ public class XAuthTokenFilterTest {
 		final MockHttpServletResponse response = new MockHttpServletResponse();
 		final MockFilterChain filterChain = new MockFilterChain();
 
-		request.setRequestURI("/brapi");
-		request.addHeader(XAuthTokenFilter.AUTH_TOKEN_HEADER_NAME, XAuthTokenFilter.BEARER_PREFIX + token.getToken());
+		request.addHeader(XAuthTokenFilter.OAUTH_TOKEN_HEADER_NAME, XAuthTokenFilter.OAUTH_TOKEN_PREFIX + token.getToken());
 
 		final XAuthTokenFilter filter = new XAuthTokenFilter(this.userDetailsService, this.tokenProvider);
 		filter.doFilter(request, response, filterChain);
@@ -148,8 +146,7 @@ public class XAuthTokenFilterTest {
 		final MockHttpServletResponse response = new MockHttpServletResponse();
 		final MockFilterChain filterChain = new MockFilterChain();
 
-		request.setRequestURI("/brapi");
-		request.addHeader(XAuthTokenFilter.AUTH_TOKEN_HEADER_NAME, XAuthTokenFilter.BEARER_PREFIX + token.getToken());
+		request.addHeader(XAuthTokenFilter.OAUTH_TOKEN_HEADER_NAME, XAuthTokenFilter.OAUTH_TOKEN_PREFIX + token.getToken());
 
 		final XAuthTokenFilter filter = new XAuthTokenFilter(this.userDetailsService, this.tokenProvider);
 		filter.doFilter(request, response, filterChain);


### PR DESCRIPTION
## Problem

OAuth token format was only limited to brapi, but there is one scenario where the url is not `/brapi`: spring error handling where a second request to `/error` passes through the filter (coming from `org.springframework.boot.context.web.ErrorPageFilter#handleErrorStatus`, that forwards every response with status >= 400), and in that case the oauth token should be used too. If not, the request will not pass authentication and the response will be the one of `Http401UnauthorizedEntryPoint`.
The problem doesn't manifest in swagger because [it sends both headers](https://github.com/IntegratedBreedingPlatform/BMSAPI/blob/e2c55b781dfec7123f3582cf9264d4634919b67f/src/main/webapp/WEB-INF/html/index.html#L93), and so for `/error` the X-Auth-Token is used, and the authentication is set correctly.

## Solution

To overcome this, I've switched it to a workflow where the oauth token is used if the header is available (regardless of the URL), and if not we fall back to X-Auth-Token.
This shouldn't be a problem because internally both tokens are the same and the idea is to move to oauth for bmsapi eventually. This was also briefly mentioned in #59 

## Other alternatives I've looked into

- Disabling Spring Whitelabel Error Page
```java
@SpringBootApplication(exclude = {
	DataSourceAutoConfiguration.class,
	DataSourceTransactionManagerAutoConfiguration.class,
	ErrorMvcAutoConfiguration.class
})
```
Doing that, there is no `/error` request, and so the response status is right (403), but the response body is the one provided by tomcat (html)
- Try to exclude `/error` from authentication in SecurityConfiguration
```java
.antMatchers("/",
...
"/error").permitAll()
```
This one resulted in `java.lang.IllegalStateException: getWriter() has already been called for this response`.

##

cc @IntegratedBreedingPlatform/developers 