### PR TITLE
IBP-4096-UpdateInvalidLotUnitId

### DIFF
--- a/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/LotInputValidator.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/LotInputValidator.java
@@ -13,6 +13,7 @@ import org.generationcp.middleware.domain.inventory.manager.TransactionsSearchDt
 import org.generationcp.middleware.pojos.ims.TransactionStatus;
 import org.generationcp.middleware.service.api.inventory.LotService;
 import org.generationcp.middleware.service.api.inventory.TransactionService;
+import org.generationcp.middleware.util.StringUtil;
 import org.ibp.api.exception.ApiRequestValidationException;
 import org.ibp.api.java.impl.middleware.common.validator.BaseValidator;
 import org.ibp.api.java.impl.middleware.common.validator.GermplasmValidator;
@@ -167,7 +168,7 @@ public class LotInputValidator {
 			return;
 		}
 
-		if (transactionDtos.stream().map(TransactionDto::getTransactionStatus)
+		if (transactionDtos.stream().filter(transactionDto ->  !StringUtil.isEmpty(transactionDto.getLot().getUnitName())).map(TransactionDto::getTransactionStatus)
 			.anyMatch(s -> s.equals(TransactionStatus.CONFIRMED.getValue()))
 		) {
 

--- a/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/LotInputValidator.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/inventory/manager/validator/LotInputValidator.java
@@ -67,7 +67,7 @@ public class LotInputValidator {
 		this.inventoryUnitValidator.validateInventoryUnitId(this.errors, lotGeneratorInputDto.getUnitId());
 		this.germplasmValidator.validateGermplasmId(this.errors, lotGeneratorInputDto.getGid());
 		this.validateStockId(lotGeneratorInputDto);
-		this.inventoryCommonValidator.validateLotNotes(lotGeneratorInputDto.getNotes(), errors);
+		this.inventoryCommonValidator.validateLotNotes(lotGeneratorInputDto.getNotes(), this.errors);
 		if (this.errors.hasErrors()) {
 			throw new ApiRequestValidationException(this.errors.getAllErrors());
 		}
@@ -81,7 +81,7 @@ public class LotInputValidator {
 		this.locationValidator.validateSeedLocationId(this.errors, programUUID, lotGeneratorInputDto.getLocationId());
 		this.inventoryUnitValidator.validateInventoryUnitId(this.errors, lotGeneratorInputDto.getUnitId());
 		this.validateStockId(lotGeneratorInputDto);
-		this.inventoryCommonValidator.validateLotNotes(lotGeneratorInputDto.getNotes(), errors);
+		this.inventoryCommonValidator.validateLotNotes(lotGeneratorInputDto.getNotes(), this.errors);
 		if (this.errors.hasErrors()) {
 			throw new ApiRequestValidationException(this.errors.getAllErrors());
 		}
@@ -108,7 +108,7 @@ public class LotInputValidator {
 				this.germplasmValidator.validateGermplasmId(this.errors, gid);
 			}
 
-			this.inventoryCommonValidator.validateLotNotes(lotUpdateRequestDto.getSingleInput().getNotes(), errors);
+			this.inventoryCommonValidator.validateLotNotes(lotUpdateRequestDto.getSingleInput().getNotes(), this.errors);
 			if (lotUpdateRequestDto.getSingleInput().getUnitId() != null) {
 				final List<String> lotUUids = lotDtos.stream().map(extendedLotDto -> extendedLotDto.getLotUUID()).collect(Collectors.toList());
 				this.validateNoConfirmedTransactions(lotUUids);
@@ -126,15 +126,15 @@ public class LotInputValidator {
 				lotUpdateRequestDto.getMultiInput().getLotList().stream().map(LotMultiUpdateRequestDto.LotUpdateDto::getUnitName).distinct().collect(Collectors.toList());
 			if (unitNames.stream().anyMatch(s -> !StringUtils.isBlank(s))) {
 				if (unitNames.stream().anyMatch(s -> StringUtils.isBlank(s))) {
-					errors.reject("lot.input.list.units.null.or.empty", "");
+					this.errors.reject("lot.input.list.units.null.or.empty", "");
 				} else {
-					this.inventoryCommonValidator.validateUnitNames(unitNames, errors);
+					this.inventoryCommonValidator.validateUnitNames(unitNames, this.errors);
 				}
 			}
 
 			final List<String> notesList = lotUpdateRequestDto.getMultiInput().getLotList().stream().map(LotMultiUpdateRequestDto.LotUpdateDto::getNotes).distinct().collect(Collectors.toList());
 			if (notesList.stream().anyMatch(s -> !StringUtils.isBlank(s))) {
-				this.inventoryCommonValidator.validateLotNotes(notesList, errors);
+				this.inventoryCommonValidator.validateLotNotes(notesList, this.errors);
 			}
 
 			final List<String> lotUUids =
@@ -201,7 +201,7 @@ public class LotInputValidator {
 				this.errors.reject("lot.stock.prefix.not.empty", "");
 			}
 		} else {
-			inventoryCommonValidator.validateStockIdPrefix(lotGeneratorInputDto.getStockPrefix(), errors);
+			this.inventoryCommonValidator.validateStockIdPrefix(lotGeneratorInputDto.getStockPrefix(), this.errors);
 			if (!StringUtils.isEmpty(lotGeneratorInputDto.getStockId())){
 				this.errors.reject("lot.stock.id.not.empty", "");
 				return;

--- a/src/test/java/org/ibp/api/java/impl/middleware/inventory/LotInputValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/inventory/LotInputValidatorTest.java
@@ -74,7 +74,7 @@ public class LotInputValidatorTest {
 
 	@Test(expected = ApiRequestValidationException.class)
 	public void testValidateDataComments() {
-		Mockito.doCallRealMethod().when(inventoryCommonValidator).validateLotNotes(Mockito.anyString(), Mockito.any(BindingResult.class));
+		Mockito.doCallRealMethod().when(this.inventoryCommonValidator).validateLotNotes(Mockito.anyString(), Mockito.any(BindingResult.class));
 		this.lotGeneratorInputDto.setGid(GID);
 		this.lotGeneratorInputDto.setLocationId(LOCATION_ID);
 		this.lotGeneratorInputDto.setGenerateStock(false);
@@ -162,19 +162,22 @@ public class LotInputValidatorTest {
 		final ExtendedLotDto extendedLotDto = this.getExtendedlotDto("SEED");
 		final LotUpdateRequestDto lotUpdateRequestDto = new LotUpdateRequestDto();
 		lotUpdateRequestDto.setSingleInput(this.getLotSingleUpdateRequestDto());
-		Mockito.when(transactionService.searchTransactions(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(this.getMockedTransactionsSearchDTO(extendedLotDto));
+		Mockito.when(this.transactionService.searchTransactions(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(this.getMockedTransactionsSearchDTO(extendedLotDto));
 		this.lotInputValidator.validate(null, Arrays.asList(extendedLotDto), lotUpdateRequestDto);
 	}
 
 	@Test
 	public void testInValidateUnitIdAndNameConfirm() {
-		boolean pass = false;
+		boolean pass = true;
 		final ExtendedLotDto extendedLotDto = this.getExtendedlotDto("");
 		final LotUpdateRequestDto lotUpdateRequestDto = new LotUpdateRequestDto();
 		lotUpdateRequestDto.setSingleInput(this.getLotSingleUpdateRequestDto());
-		Mockito.when(transactionService.searchTransactions(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(this.getMockedTransactionsSearchDTO(extendedLotDto));
-		this.lotInputValidator.validate(null, Arrays.asList(extendedLotDto), lotUpdateRequestDto);
-		pass = true;
+		Mockito.when(this.transactionService.searchTransactions(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(this.getMockedTransactionsSearchDTO(extendedLotDto));
+		try {
+			this.lotInputValidator.validate(null, Arrays.asList(extendedLotDto), lotUpdateRequestDto);
+		} catch (final Exception e) {
+			pass = false;
+		}
 		Assert.assertTrue("No exception, existing unit id is not valid and can be updated.", pass);
 	}
 

--- a/src/test/java/org/ibp/api/java/impl/middleware/inventory/LotInputValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/inventory/LotInputValidatorTest.java
@@ -1,8 +1,13 @@
 package org.ibp.api.java.impl.middleware.inventory;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.generationcp.middleware.domain.inventory.manager.ExtendedLotDto;
 import org.generationcp.middleware.domain.inventory.manager.LotGeneratorInputDto;
+import org.generationcp.middleware.domain.inventory.manager.LotSingleUpdateRequestDto;
+import org.generationcp.middleware.domain.inventory.manager.LotUpdateRequestDto;
+import org.generationcp.middleware.domain.inventory.manager.TransactionDto;
 import org.generationcp.middleware.domain.oms.TermId;
+import org.generationcp.middleware.pojos.ims.TransactionStatus;
 import org.generationcp.middleware.service.api.inventory.LotService;
 import org.generationcp.middleware.service.api.inventory.TransactionService;
 import org.ibp.api.exception.ApiRequestValidationException;
@@ -12,14 +17,20 @@ import org.ibp.api.java.impl.middleware.common.validator.LocationValidator;
 import org.ibp.api.java.impl.middleware.inventory.common.validator.InventoryCommonValidator;
 import org.ibp.api.java.impl.middleware.inventory.manager.validator.ExtendedLotListValidator;
 import org.ibp.api.java.impl.middleware.inventory.manager.validator.LotInputValidator;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.validation.BindingResult;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LotInputValidatorTest {
@@ -144,5 +155,65 @@ public class LotInputValidatorTest {
 		this.lotGeneratorInputDto.setStockId(RandomStringUtils.randomAlphabetic(40));
 
 		this.lotInputValidator.validate(null, this.lotGeneratorInputDto);
+	}
+
+	@Test(expected = ApiRequestValidationException.class)
+	public void testValidUnitIdAndNameConfirm() {
+		final ExtendedLotDto extendedLotDto = this.getExtendedlotDto("SEED");
+		final LotUpdateRequestDto lotUpdateRequestDto = new LotUpdateRequestDto();
+		lotUpdateRequestDto.setSingleInput(this.getLotSingleUpdateRequestDto());
+		Mockito.when(transactionService.searchTransactions(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(this.getMockedTransactionsSearchDTO(extendedLotDto));
+		this.lotInputValidator.validate(null, Arrays.asList(extendedLotDto), lotUpdateRequestDto);
+	}
+
+	@Test
+	public void testInValidateUnitIdAndNameConfirm() {
+		boolean pass = false;
+		final ExtendedLotDto extendedLotDto = this.getExtendedlotDto("");
+		final LotUpdateRequestDto lotUpdateRequestDto = new LotUpdateRequestDto();
+		lotUpdateRequestDto.setSingleInput(this.getLotSingleUpdateRequestDto());
+		Mockito.when(transactionService.searchTransactions(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(this.getMockedTransactionsSearchDTO(extendedLotDto));
+		this.lotInputValidator.validate(null, Arrays.asList(extendedLotDto), lotUpdateRequestDto);
+		pass = true;
+		Assert.assertTrue("No exception, existing unit id is not valid and can be updated.", pass);
+	}
+
+	private ExtendedLotDto getExtendedlotDto(final String unitname) {
+		final int unitId = unitname == null ? 0 : UNIT_ID;
+		final ExtendedLotDto extendedLotDto = new ExtendedLotDto();
+		extendedLotDto.setActualBalance(100.0);
+		extendedLotDto.setAvailableBalance(100.0);
+		extendedLotDto.setCreatedByUsername("admin");
+		extendedLotDto.setCreatedDate(new Date());
+		extendedLotDto.setDesignation("SAMPLE");
+		extendedLotDto.setGermplasmLocation(String.valueOf(LOCATION_ID));
+		extendedLotDto.setGermplasmMethodName("Derivative");
+		extendedLotDto.setUnitName(unitname);
+		extendedLotDto.setGid(GID);
+		extendedLotDto.setUnitId(unitId);
+		extendedLotDto.setLocationName("SAMPLE");
+		extendedLotDto.setLotId(1);
+		extendedLotDto.setStockId(STOCK_PREFIX+STOCK_ID);
+		extendedLotDto.setNotes(COMMENTS);
+		return extendedLotDto;
+	}
+
+	private LotSingleUpdateRequestDto getLotSingleUpdateRequestDto() {
+		final LotSingleUpdateRequestDto lotSingleUpdateRequestDto = new LotSingleUpdateRequestDto();
+		lotSingleUpdateRequestDto.setGid(GID);
+		lotSingleUpdateRequestDto.setLocationId(LOCATION_ID);
+		lotSingleUpdateRequestDto.setNotes(COMMENTS);
+		lotSingleUpdateRequestDto.setUnitId(UNIT_ID);
+		return lotSingleUpdateRequestDto;
+	}
+
+	private List<TransactionDto> getMockedTransactionsSearchDTO(final ExtendedLotDto extendedLotDto) {
+		final TransactionDto transactionDto = new TransactionDto();
+		transactionDto.setAmount(100.0);
+		transactionDto.setLot(extendedLotDto);
+		transactionDto.setTransactionId(1);
+		transactionDto.setTransactionStatus(TransactionStatus.CONFIRMED.getValue());
+		transactionDto.setNotes(COMMENTS);
+		return Arrays.asList(transactionDto);
 	}
 }


### PR DESCRIPTION
Modify stream logic, only throw exception if lot to be updated has valid unit id and confirm transaction status