### PR TITLE
IBP-3723 Fix File Downloads on Firefox

### DIFF
--- a/src/main/java/org/ibp/api/rest/dataset/DatasetResource.java
+++ b/src/main/java/org/ibp/api/rest/dataset/DatasetResource.java
@@ -347,6 +347,7 @@ public class DatasetResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
+		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/dataset/DatasetResource.java
+++ b/src/main/java/org/ibp/api/rest/dataset/DatasetResource.java
@@ -347,7 +347,7 @@ public class DatasetResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
-		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
+		headers.add(HttpHeaders.CONTENT_TYPE, String.format("%s;charset=utf-8", FileUtils.detectMimeType(file.getName())));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/germplasm/GermplasmResource.java
+++ b/src/main/java/org/ibp/api/rest/germplasm/GermplasmResource.java
@@ -169,7 +169,7 @@ public class GermplasmResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
-		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
+		headers.add(HttpHeaders.CONTENT_TYPE, String.format("%s;charset=utf-8", FileUtils.detectMimeType(file.getName())));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/germplasm/GermplasmResource.java
+++ b/src/main/java/org/ibp/api/rest/germplasm/GermplasmResource.java
@@ -169,6 +169,7 @@ public class GermplasmResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
+		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/inventory/manager/LotResource.java
+++ b/src/main/java/org/ibp/api/rest/inventory/manager/LotResource.java
@@ -289,6 +289,7 @@ public class LotResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
+		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/inventory/manager/LotResource.java
+++ b/src/main/java/org/ibp/api/rest/inventory/manager/LotResource.java
@@ -289,7 +289,7 @@ public class LotResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
-		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
+		headers.add(HttpHeaders.CONTENT_TYPE, String.format("%s;charset=utf-8", FileUtils.detectMimeType(file.getName())));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/inventory/manager/TransactionResource.java
+++ b/src/main/java/org/ibp/api/rest/inventory/manager/TransactionResource.java
@@ -256,7 +256,7 @@ public class TransactionResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
-		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
+		headers.add(HttpHeaders.CONTENT_TYPE, String.format("%s;charset=utf-8", FileUtils.detectMimeType(file.getName())));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/inventory/manager/TransactionResource.java
+++ b/src/main/java/org/ibp/api/rest/inventory/manager/TransactionResource.java
@@ -256,6 +256,7 @@ public class TransactionResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 			.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
+		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/labelprinting/LabelPrintingResource.java
+++ b/src/main/java/org/ibp/api/rest/labelprinting/LabelPrintingResource.java
@@ -146,6 +146,7 @@ public class LabelPrintingResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 				.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
+		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/labelprinting/LabelPrintingResource.java
+++ b/src/main/java/org/ibp/api/rest/labelprinting/LabelPrintingResource.java
@@ -146,7 +146,7 @@ public class LabelPrintingResource {
 		final HttpHeaders headers = new HttpHeaders();
 		headers
 				.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", FileUtils.sanitizeFileName(file.getName())));
-		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(file.getName()));
+		headers.add(HttpHeaders.CONTENT_TYPE, String.format("%s;charset=utf-8", FileUtils.detectMimeType(file.getName())));
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 		return new ResponseEntity<>(fileSystemResource, headers, HttpStatus.OK);
 	}

--- a/src/main/java/org/ibp/api/rest/sample/SampleListResource.java
+++ b/src/main/java/org/ibp/api/rest/sample/SampleListResource.java
@@ -183,8 +183,7 @@ public class SampleListResource {
 
 		final HttpHeaders headers = new HttpHeaders();
 		headers.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", exportInfo.getDownloadFileName()));
-		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(exportInfo.getDownloadFileName()));
-
+		headers.add(HttpHeaders.CONTENT_TYPE, String.format("%s;charset=utf-8", FileUtils.detectMimeType(exportInfo.getDownloadFileName())));
 		final File file = new File(exportInfo.getFilePath());
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);
 

--- a/src/main/java/org/ibp/api/rest/sample/SampleListResource.java
+++ b/src/main/java/org/ibp/api/rest/sample/SampleListResource.java
@@ -7,6 +7,7 @@ import org.generationcp.commons.pojo.FileExportInfo;
 import org.generationcp.commons.pojo.treeview.TreeNode;
 import org.generationcp.commons.service.CsvExportSampleListService;
 import org.generationcp.commons.service.impl.CsvExportSampleListServiceImpl;
+import org.generationcp.commons.util.FileUtils;
 import org.generationcp.middleware.domain.sample.SampleDTO;
 import org.generationcp.middleware.domain.sample.SampleDetailsDTO;
 import org.generationcp.middleware.exceptions.MiddlewareException;
@@ -182,6 +183,7 @@ public class SampleListResource {
 
 		final HttpHeaders headers = new HttpHeaders();
 		headers.add(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=%s", exportInfo.getDownloadFileName()));
+		headers.add(HttpHeaders.CONTENT_TYPE, FileUtils.detectMimeType(exportInfo.getDownloadFileName()));
 
 		final File file = new File(exportInfo.getFilePath());
 		final FileSystemResource fileSystemResource = new FileSystemResource(file);


### PR DESCRIPTION
Set the appropriate content type of files for download. This is to make sure that the browser will correctly detect the file type of the data being downloaded.

IBP-3723