### PR TITLE
IBP-4198-FixNameLimitAndFormat

### DIFF
--- a/src/main/java/org/ibp/api/java/impl/middleware/dataset/AbstractDatasetExportService.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/dataset/AbstractDatasetExportService.java
@@ -129,7 +129,8 @@ public abstract class AbstractDatasetExportService {
 		final String dataSetName =
 			DatasetTypeEnum.PLOT_DATA.getId() == dataSet.getDatasetTypeId() ? DatasetServiceImpl.PLOT_DATASET_NAME : dataSet.getName();
 		final String sanitizedFileName = FileUtils.sanitizeFileName(String.format("%s_%s.%s", study.getName(), dataSetName, fileExtension));
-		final String fileNameFullPath = temporaryFolder.getAbsolutePath() + File.separator + sanitizedFileName;
+		final String formattedFileName = FileNameGenerator.generateFileName(sanitizedFileName);
+		final String fileNameFullPath = temporaryFolder.getAbsolutePath() + File.separator + formattedFileName;
 
 		return generator.generateMultiInstanceFile(observationUnitRowMap, columns, fileNameFullPath);
 	}


### PR DESCRIPTION
Formatted filename should be applied when creating the temporary files
Filename will be truncated if filename w/o extension exceeds to 200 and if with extension exceeds to 255 