### PR TITLE
IBP-4349-BrapiUseGermplsmGUID

### DIFF
--- a/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
@@ -185,8 +185,6 @@ public class GermplasmResourceBrapi {
 		if (germplasmDTO != null) {
 			final ModelMapper mapper = new ModelMapper();
 			final Germplasm germplasm = mapper.map(germplasmDTO, Germplasm.class);
-			germplasm.setCommonCropName(crop);
-
 			final SingleEntityResponse<Germplasm> singleGermplasmResponse = new SingleEntityResponse<>(germplasm);
 
 			return new ResponseEntity<>(singleGermplasmResponse, HttpStatus.OK);

--- a/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
@@ -180,15 +180,7 @@ public class GermplasmResourceBrapi {
 		@PathVariable final String crop,
 		@PathVariable final String germplasmDbId) {
 
-		final int gid;
-		try {
-			gid = Integer.parseInt(germplasmDbId);
-		} catch (final NumberFormatException e) {
-			return new ResponseEntity<>(new SingleEntityResponse<Germplasm>().withMessage("no germplasm found"), HttpStatus.NOT_FOUND);
-
-		}
-
-		final GermplasmDTO germplasmDTO = this.germplasmService.getGermplasmDTObyGID(gid);
+		final GermplasmDTO germplasmDTO = this.germplasmService.getGermplasmDTObyGUID(germplasmDbId);
 
 		if (germplasmDTO != null) {
 			final ModelMapper mapper = new ModelMapper();
@@ -223,14 +215,7 @@ public class GermplasmResourceBrapi {
 				new SingleEntityResponse<PedigreeDTO>().withMessage("Search by pedigree not implemented"), HttpStatus.NOT_IMPLEMENTED);
 		}
 
-		final int gid;
-		try {
-			gid = Integer.parseInt(germplasmDbId);
-		} catch (final NumberFormatException e) {
-			return new ResponseEntity<>(new SingleEntityResponse<PedigreeDTO>().withMessage("no germplasm found"), HttpStatus.NOT_FOUND);
-		}
-
-		final PedigreeDTO pedigreeDTO = this.germplasmService.getPedigree(gid, null, includeSiblings);
+		final PedigreeDTO pedigreeDTO = this.germplasmService.getPedigree(germplasmDbId, null, includeSiblings);
 		if (pedigreeDTO == null) {
 			return new ResponseEntity<>(new SingleEntityResponse<PedigreeDTO>().withMessage("no germplasm found"), HttpStatus.NOT_FOUND);
 		}
@@ -247,14 +232,7 @@ public class GermplasmResourceBrapi {
 		@PathVariable(value = "germplasmDbId") final String germplasmDbId
 	) {
 
-		final int gid;
-		try {
-			gid = Integer.parseInt(germplasmDbId);
-		} catch (final NumberFormatException e) {
-			return new ResponseEntity<>(new SingleEntityResponse<ProgenyDTO>().withMessage("no germplasm found"), HttpStatus.NOT_FOUND);
-		}
-
-		final ProgenyDTO progenyDTO = this.germplasmService.getProgeny(gid);
+		final ProgenyDTO progenyDTO = this.germplasmService.getProgeny(germplasmDbId);
 		if (progenyDTO == null) {
 			return new ResponseEntity<>(new SingleEntityResponse<ProgenyDTO>().withMessage("no germplasm found"), HttpStatus.NOT_FOUND);
 		}
@@ -426,14 +404,14 @@ public class GermplasmResourceBrapi {
 
 				@Override
 				public long getCount() {
-					return GermplasmResourceBrapi.this.germplasmService.countAttributesByGid(germplasmDbId, attributeDbIds);
+					return GermplasmResourceBrapi.this.germplasmService.countAttributesByGermplasmGUID(germplasmDbId, attributeDbIds);
 				}
 
 				@Override
 				public List<AttributeDTO> getResults(final PagedResult<AttributeDTO> pagedResult) {
 					final int pageNumber = pagedResult.getPageNumber() + 1;
 					return GermplasmResourceBrapi.this.germplasmService
-						.getAttributesByGid(germplasmDbId, attributeDbIds, pagedResult.getPageSize(), pageNumber);
+						.getAttributesByGermplasmGUID(germplasmDbId, attributeDbIds, pagedResult.getPageSize(), pageNumber);
 				}
 			});
 

--- a/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
@@ -399,8 +399,12 @@ public class GermplasmResourceBrapi {
 		@RequestParam(value = "pageSize",
 			required = false) final Integer pageSize
 	) {
+
+		final int finalPageNumber = currentPage == null ? BrapiPagedResult.DEFAULT_PAGE_NUMBER : currentPage;
+		final int finalPageSize = pageSize == null ? BrapiPagedResult.DEFAULT_PAGE_SIZE : pageSize;
+
 		final PagedResult<AttributeDTO> resultPage =
-			new PaginatedSearch().executeBrapiSearch(currentPage, pageSize, new SearchSpec<AttributeDTO>() {
+			new PaginatedSearch().executeBrapiSearch(finalPageNumber, finalPageSize, new SearchSpec<AttributeDTO>() {
 
 				@Override
 				public long getCount() {
@@ -411,7 +415,7 @@ public class GermplasmResourceBrapi {
 				public List<AttributeDTO> getResults(final PagedResult<AttributeDTO> pagedResult) {
 					final int pageNumber = pagedResult.getPageNumber() + 1;
 					return GermplasmResourceBrapi.this.germplasmService
-						.getAttributesByGUID(germplasmDbId, attributeDbIds, pagedResult.getPageSize(), pageNumber);
+						.getAttributesByGUID(germplasmDbId, attributeDbIds, new PageRequest(finalPageNumber, pagedResult.getPageSize()));
 				}
 			});
 

--- a/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
@@ -411,9 +411,8 @@ public class GermplasmResourceBrapi {
 
 				@Override
 				public List<AttributeDTO> getResults(final PagedResult<AttributeDTO> pagedResult) {
-					final int pageNumber = pagedResult.getPageNumber() + 1;
 					return GermplasmResourceBrapi.this.germplasmService
-						.getAttributesByGUID(germplasmDbId, attributeDbIds, new PageRequest(pageNumber, pagedResult.getPageSize()));
+						.getAttributesByGUID(germplasmDbId, attributeDbIds, new PageRequest(finalPageNumber, finalPageSize));
 				}
 			});
 

--- a/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
@@ -415,7 +415,7 @@ public class GermplasmResourceBrapi {
 				public List<AttributeDTO> getResults(final PagedResult<AttributeDTO> pagedResult) {
 					final int pageNumber = pagedResult.getPageNumber() + 1;
 					return GermplasmResourceBrapi.this.germplasmService
-						.getAttributesByGUID(germplasmDbId, attributeDbIds, new PageRequest(finalPageNumber, pagedResult.getPageSize()));
+						.getAttributesByGUID(germplasmDbId, attributeDbIds, new PageRequest(pageNumber, pagedResult.getPageSize()));
 				}
 			});
 

--- a/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapi.java
@@ -404,14 +404,14 @@ public class GermplasmResourceBrapi {
 
 				@Override
 				public long getCount() {
-					return GermplasmResourceBrapi.this.germplasmService.countAttributesByGermplasmGUID(germplasmDbId, attributeDbIds);
+					return GermplasmResourceBrapi.this.germplasmService.countAttributesByGUID(germplasmDbId, attributeDbIds);
 				}
 
 				@Override
 				public List<AttributeDTO> getResults(final PagedResult<AttributeDTO> pagedResult) {
 					final int pageNumber = pagedResult.getPageNumber() + 1;
 					return GermplasmResourceBrapi.this.germplasmService
-						.getAttributesByGermplasmGUID(germplasmDbId, attributeDbIds, pagedResult.getPageSize(), pageNumber);
+						.getAttributesByGUID(germplasmDbId, attributeDbIds, pagedResult.getPageSize(), pageNumber);
 				}
 			});
 

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/LotDetails.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/LotDetails.java
@@ -42,7 +42,7 @@ public class LotDetails {
     private Map<String, Object> additionalInfo = new HashMap<>();
 
     public Map<String, Object> getAdditionalInfo() {
-        return additionalInfo;
+        return this.additionalInfo;
     }
 
     public void setAdditionalInfo(final Map<String, Object> additionalInfo) {
@@ -50,7 +50,7 @@ public class LotDetails {
     }
 
     public Double getAmount() {
-        return amount;
+        return this.amount;
     }
 
     public void setAmount(final Double amount) {
@@ -58,7 +58,7 @@ public class LotDetails {
     }
 
     public Date getCreatedDate() {
-        return createdDate;
+        return this.createdDate;
     }
 
     public void setCreatedDate(final Date createdDate) {
@@ -66,7 +66,7 @@ public class LotDetails {
     }
 
     public Date getLastUpdated() {
-        return lastUpdated;
+        return this.lastUpdated;
     }
 
     public void setLastUpdated(final Date lastUpdated) {
@@ -74,7 +74,7 @@ public class LotDetails {
     }
 
     public String getGermplasmDbId() {
-        return germplasmDbId;
+        return this.germplasmDbId;
     }
 
     public void setGermplasmDbId(final String germplasmDbId) {
@@ -82,7 +82,7 @@ public class LotDetails {
     }
 
     public Integer getLocationDbId() {
-        return locationDbId;
+        return this.locationDbId;
     }
 
     public void setLocationDbId(final Integer locationDbId) {
@@ -90,7 +90,7 @@ public class LotDetails {
     }
 
     public String getProgramDbId() {
-        return programDbId;
+        return this.programDbId;
     }
 
     public void setProgramDbId(final String programDbId) {
@@ -98,7 +98,7 @@ public class LotDetails {
     }
 
     public String getSeedLotDescription() {
-        return seedLotDescription;
+        return this.seedLotDescription;
     }
 
     public void setSeedLotDescription(final String seedLotDescription) {
@@ -106,7 +106,7 @@ public class LotDetails {
     }
 
     public String getSeedLotName() {
-        return seedLotName;
+        return this.seedLotName;
     }
 
     public void setSeedLotName(final String seedLotName) {
@@ -114,7 +114,7 @@ public class LotDetails {
     }
 
     public String getSourceCollection() {
-        return sourceCollection;
+        return this.sourceCollection;
     }
 
     public void setSourceCollection(final String sourceCollection) {
@@ -122,7 +122,7 @@ public class LotDetails {
     }
 
     public String getStorageLocation() {
-        return storageLocation;
+        return this.storageLocation;
     }
 
     public void setStorageLocation(final String storageLocation) {
@@ -130,7 +130,7 @@ public class LotDetails {
     }
 
     public String getUnits() {
-        return units;
+        return this.units;
     }
 
     public void setUnits(final String units) {
@@ -138,7 +138,7 @@ public class LotDetails {
     }
 
     public String getSeedLotDbId() {
-        return seedLotDbId;
+        return this.seedLotDbId;
     }
 
     public void setSeedLotDbId(final String seedLotDbId) {
@@ -156,7 +156,7 @@ public class LotDetails {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         return Pojomatic.equals(this, o);
     }
 }

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/LotDetails.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/LotDetails.java
@@ -21,7 +21,7 @@ public class LotDetails {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private Date lastUpdated;
 
-    private Integer germplasmDbId;
+    private String germplasmDbId;
 
     private Integer locationDbId;
 
@@ -73,11 +73,11 @@ public class LotDetails {
         this.lastUpdated = lastUpdated;
     }
 
-    public Integer getGermplasmDbId() {
+    public String getGermplasmDbId() {
         return germplasmDbId;
     }
 
-    public void setGermplasmDbId(final Integer germplasmDbId) {
+    public void setGermplasmDbId(final String germplasmDbId) {
         this.germplasmDbId = germplasmDbId;
     }
 

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/LotMapper.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/LotMapper.java
@@ -57,7 +57,7 @@ public class LotMapper {
                 this.using(new AdditionalInfoConverter()).map(this.source).setAdditionalInfo(null);
                 this.map().setAmount(this.source.getAvailableBalance());
                 this.map().setCreatedDate(this.source.getCreatedDate());
-                this.map().setGermplasmDbId(this.source.getGid());
+                this.map().setGermplasmDbId(this.source.getGermplasmUUID());
                 this.map().setLocationDbId(this.source.getLocationId());
                 this.map().setSeedLotDescription(this.source.getNotes());
                 this.map().setSeedLotName(this.source.getStockId());

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/LotResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/LotResourceBrapi.java
@@ -54,7 +54,7 @@ public class LotResourceBrapi {
             lotsSearchDto.setLotUUIDs(Collections.singletonList(seedLotDbId));
         }
         if (germplasmDbId != null) {
-            lotsSearchDto.setGids(Collections.singletonList(Integer.valueOf(germplasmDbId)));
+            lotsSearchDto.setGermplasmGUIDs(Collections.singletonList(germplasmDbId));
         }
         // Only retrieve Active Lots
         lotsSearchDto.setStatus(LotStatus.ACTIVE.getIntValue());

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/LotResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/LotResourceBrapi.java
@@ -54,7 +54,7 @@ public class LotResourceBrapi {
             lotsSearchDto.setLotUUIDs(Collections.singletonList(seedLotDbId));
         }
         if (germplasmDbId != null) {
-            lotsSearchDto.setGermplasmGUIDs(Collections.singletonList(germplasmDbId));
+            lotsSearchDto.setGermplasmUUIDs(Collections.singletonList(germplasmDbId));
         }
         // Only retrieve Active Lots
         lotsSearchDto.setStatus(LotStatus.ACTIVE.getIntValue());

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/TransactionMapper.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/TransactionMapper.java
@@ -36,7 +36,7 @@ public class TransactionMapper {
 			additionalInfo.put("transactionType", transactionDto.getTransactionType());
 			additionalInfo.put("transactionStatus", transactionDto.getTransactionStatus());
 			additionalInfo.put("seedLotID", transactionDto.getLot().getLotUUID());
-			additionalInfo.put("germplasmDbId", transactionDto.getLot().getGid());
+			additionalInfo.put("germplasmDbId", transactionDto.getLot().getGermplasmUUID());
 			additionalInfo.put("designation", transactionDto.getLot().getDesignation());
 			additionalInfo.put("locationId", transactionDto.getLot().getLocationId());
 			additionalInfo.put("locationName", transactionDto.getLot().getLocationName());

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/TransactionResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/TransactionResourceBrapi.java
@@ -92,7 +92,8 @@ public class TransactionResourceBrapi {
 		}
 
 		if(!StringUtils.isEmpty(germplasmDbId)) {
-			searchDTO.setGids(Collections.singletonList(Integer.valueOf(germplasmDbId)));
+			// GermplasmDbID = Germplasm_UUID
+			searchDTO.setGermplasmGuids(Collections.singletonList(germplasmDbId));
 		}
 
 		if(!StringUtils.isEmpty(seedLotDbId)) {

--- a/src/main/java/org/ibp/api/brapi/v2/inventory/TransactionResourceBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v2/inventory/TransactionResourceBrapi.java
@@ -93,7 +93,7 @@ public class TransactionResourceBrapi {
 
 		if(!StringUtils.isEmpty(germplasmDbId)) {
 			// GermplasmDbID = Germplasm_UUID
-			searchDTO.setGermplasmGuids(Collections.singletonList(germplasmDbId));
+			searchDTO.setGermplasmUUIDs(Collections.singletonList(germplasmDbId));
 		}
 
 		if(!StringUtils.isEmpty(seedLotDbId)) {

--- a/src/main/java/org/ibp/api/java/germplasm/GermplasmService.java
+++ b/src/main/java/org/ibp/api/java/germplasm/GermplasmService.java
@@ -52,7 +52,7 @@ public interface GermplasmService {
 	List<GermplasmDTO> getGermplasmByStudy(int studyDbId, Pageable pageable);
 
 	List<AttributeDTO> getAttributesByGUID(
-		String germplasmUUID, List<String> attributeDbIds, Integer pageSize, Integer pageNUmber);
+		String germplasmUUID, List<String> attributeDbIds, Pageable pageable);
 
 	long countAttributesByGUID(String germplasmUUID, List<String> attributeDbIds);
 

--- a/src/main/java/org/ibp/api/java/germplasm/GermplasmService.java
+++ b/src/main/java/org/ibp/api/java/germplasm/GermplasmService.java
@@ -37,11 +37,11 @@ public interface GermplasmService {
 
 	List<org.generationcp.middleware.api.nametype.GermplasmNameTypeDTO> searchNameTypes(String name);
 
-	PedigreeDTO getPedigree(Integer germplasmDbId, String notation, Boolean includeSiblings);
+	PedigreeDTO getPedigree(String germplasmDbId, String notation, Boolean includeSiblings);
 
-	ProgenyDTO getProgeny(Integer germplasmDbId);
+	ProgenyDTO getProgeny(String germplasmDbId);
 
-	GermplasmDTO getGermplasmDTObyGID(Integer germplasmId);
+	GermplasmDTO getGermplasmDTObyGUID(String germplasmGUID);
 
 	List<GermplasmDTO> searchGermplasmDTO(GermplasmSearchRequestDto germplasmSearchRequestDTO, Pageable pageable);
 
@@ -51,10 +51,10 @@ public interface GermplasmService {
 
 	List<GermplasmDTO> getGermplasmByStudy(int studyDbId, Pageable pageable);
 
-	List<AttributeDTO> getAttributesByGid(
-		String gid, List<String> attributeDbIds, Integer pageSize, Integer pageNUmber);
+	List<AttributeDTO> getAttributesByGermplasmGUID(
+		String germplasmGUID, List<String> attributeDbIds, Integer pageSize, Integer pageNUmber);
 
-	long countAttributesByGid(String gid, List<String> attributeDbIds);
+	long countAttributesByGermplasmGUID(String germplasmGUID, List<String> attributeDbIds);
 
 	Set<Integer> importGermplasmUpdates(String programUUID, List<GermplasmUpdateDTO> germplasmUpdateDTOList);
 

--- a/src/main/java/org/ibp/api/java/germplasm/GermplasmService.java
+++ b/src/main/java/org/ibp/api/java/germplasm/GermplasmService.java
@@ -41,7 +41,7 @@ public interface GermplasmService {
 
 	ProgenyDTO getProgeny(String germplasmDbId);
 
-	GermplasmDTO getGermplasmDTObyGUID(String germplasmGUID);
+	GermplasmDTO getGermplasmDTObyGUID(String germplasmUUID);
 
 	List<GermplasmDTO> searchGermplasmDTO(GermplasmSearchRequestDto germplasmSearchRequestDTO, Pageable pageable);
 
@@ -51,10 +51,10 @@ public interface GermplasmService {
 
 	List<GermplasmDTO> getGermplasmByStudy(int studyDbId, Pageable pageable);
 
-	List<AttributeDTO> getAttributesByGermplasmGUID(
-		String germplasmGUID, List<String> attributeDbIds, Integer pageSize, Integer pageNUmber);
+	List<AttributeDTO> getAttributesByGUID(
+		String germplasmUUID, List<String> attributeDbIds, Integer pageSize, Integer pageNUmber);
 
-	long countAttributesByGermplasmGUID(String germplasmGUID, List<String> attributeDbIds);
+	long countAttributesByGUID(String germplasmUUID, List<String> attributeDbIds);
 
 	Set<Integer> importGermplasmUpdates(String programUUID, List<GermplasmUpdateDTO> germplasmUpdateDTOList);
 

--- a/src/main/java/org/ibp/api/java/impl/middleware/common/validator/GermplasmValidator.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/common/validator/GermplasmValidator.java
@@ -1,9 +1,11 @@
 package org.ibp.api.java.impl.middleware.common.validator;
 
+import org.generationcp.middleware.api.brapi.v1.germplasm.GermplasmDTO;
 import org.generationcp.middleware.manager.api.GermplasmDataManager;
 import org.generationcp.middleware.pojos.Germplasm;
 import org.ibp.api.Util;
 import org.ibp.api.exception.ApiRequestValidationException;
+import org.ibp.api.java.germplasm.GermplasmService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
@@ -17,6 +19,9 @@ public class GermplasmValidator {
 
 	@Autowired
 	private GermplasmDataManager germplasmDataManager;
+
+	@Autowired
+	private GermplasmService germplasmService;
 
 	public void validateGermplasmId(final BindingResult errors, final Integer germplasmId) {
 		if (germplasmId == null) {
@@ -40,5 +45,14 @@ public class GermplasmValidator {
 			throw new ApiRequestValidationException(errors.getAllErrors());
 		}
 	}
-
+	public void validateGermplasmGUID(final BindingResult errors, final String germplasmGUID) {
+		if (germplasmGUID == null) {
+			errors.reject("germplasm.required", "");
+			return;
+		}
+		final GermplasmDTO germplasm = this.germplasmService.getGermplasmDTObyGUID(germplasmGUID);
+		if (germplasm == null) {
+			errors.reject("germplasm.invalid", "");
+		}
+	}
 }

--- a/src/main/java/org/ibp/api/java/impl/middleware/common/validator/GermplasmValidator.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/common/validator/GermplasmValidator.java
@@ -1,24 +1,23 @@
 package org.ibp.api.java.impl.middleware.common.validator;
 
 import org.generationcp.middleware.api.brapi.v1.germplasm.GermplasmDTO;
-import org.generationcp.middleware.manager.api.GermplasmDataManager;
+import org.generationcp.middleware.api.germplasm.GermplasmService;
 import org.generationcp.middleware.pojos.Germplasm;
 import org.ibp.api.Util;
 import org.ibp.api.exception.ApiRequestValidationException;
-import org.ibp.api.java.germplasm.GermplasmService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.validation.BindingResult;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
 public class GermplasmValidator {
-
-	@Autowired
-	private GermplasmDataManager germplasmDataManager;
 
 	@Autowired
 	private GermplasmService germplasmService;
@@ -28,14 +27,14 @@ public class GermplasmValidator {
 			errors.reject("germplasm.required", "");
 			return;
 		}
-		final Germplasm germplasm = this.germplasmDataManager.getGermplasmByGID(germplasmId);
-		if (germplasm == null) {
+		final List<Germplasm> germplasm = this.germplasmService.getGermplasmByGIDs(Arrays.asList(germplasmId));
+		if (CollectionUtils.isEmpty(germplasm)) {
 			errors.reject("germplasm.invalid", "");
 		}
 	}
 
 	public void validateGids(final BindingResult errors, final List<Integer> gids) {
-		final List<Germplasm> existingGermplasms = germplasmDataManager.getGermplasms(gids);
+		final List<Germplasm> existingGermplasms = this.germplasmService.getGermplasmByGIDs(gids);
 		if (existingGermplasms.size() != gids.size() || existingGermplasms.stream().filter(g -> g.getDeleted()).count() > 0) {
 			final List<Integer> existingGids =
 				existingGermplasms.stream().filter(g -> !g.getDeleted()).map(Germplasm::getGid).collect(Collectors.toList());
@@ -50,8 +49,8 @@ public class GermplasmValidator {
 			errors.reject("germplasm.required", "");
 			return;
 		}
-		final GermplasmDTO germplasm = this.germplasmService.getGermplasmDTObyGUID(germplasmGUID);
-		if (germplasm == null) {
+		final Optional<GermplasmDTO> germplasm = this.germplasmService.getGermplasmDTOByGUID(germplasmGUID);
+		if (!germplasm.isPresent()) {
 			errors.reject("germplasm.invalid", "");
 		}
 	}

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -331,7 +331,12 @@ public class GermplasmServiceImpl implements GermplasmService {
 			final String germplasmGUID, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
 		this.validateGuidAndAttributes(germplasmGUID, attributeDbIds);
 		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmGUID);
-		return this.germplasmDataManager.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
+		if (germplasmDTO.isPresent()) {
+			return this.germplasmDataManager.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
+		} else {
+			throw new ApiRuntimeException("Invalid Germplasm Id");
+		}
+
 	}
 
 	@Override
@@ -436,7 +441,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 	@Override
 	public GermplasmImportResponse createGermplasm(final String cropName, final List<GermplasmImportRequest> germplasmImportRequestList) {
 		final GermplasmImportResponse response = new GermplasmImportResponse();
-		final Integer originalListSize = germplasmImportRequestList.size();
+		final int originalListSize = germplasmImportRequestList.size();
 		int noOfCreatedGermplasm = 0;
 		// Remove germplasm that fails any validation. They will be excluded from creation
 		final BindingResult bindingResult = this.germplasmImportValidator.pruneGermplasmInvalidForImport(germplasmImportRequestList);
@@ -445,7 +450,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 		}
 		if (!CollectionUtils.isEmpty(germplasmImportRequestList)) {
 			final WorkbenchUser user = this.securityService.getCurrentlyLoggedInUser();
-			final List<GermplasmDTO> germplasmDTOList = germplasmService.createGermplasm(user.getUserid(), cropName, germplasmImportRequestList);
+			final List<GermplasmDTO> germplasmDTOList = this.germplasmService.createGermplasm(user.getUserid(), cropName, germplasmImportRequestList);
 			if (!CollectionUtils.isEmpty(germplasmDTOList)) {
 				this.populateGermplasmPedigree(germplasmDTOList);
 				noOfCreatedGermplasm = germplasmDTOList.size();

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -332,7 +332,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 		this.validateGuidAndAttributes(germplasmUUID, attributeDbIds);
 		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmUUID);
 		if (germplasmDTO.isPresent()) {
-			return this.germplasmDataManager.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
+			return this.germplasmService.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
 		} else {
 			throw new ApiRuntimeException("Invalid GermplasmDbId");
 		}
@@ -343,7 +343,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 	public long countAttributesByGUID(final String germplasmUUID, final List<String> attributeDbIds) {
 		final Optional<GermplasmDTO> germplasm = this.germplasmService.getGermplasmDTOByGUID(germplasmUUID);
 		if (germplasm.isPresent()) {
-			return this.germplasmDataManager.countAttributesByGid(germplasm.get().getGid(), attributeDbIds);
+			return this.germplasmService.countAttributesByGid(germplasm.get().getGid(), attributeDbIds);
 		} else {
 			throw new ApiRuntimeException("Invalid GermplasmDbId");
 		}

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -329,13 +329,9 @@ public class GermplasmServiceImpl implements GermplasmService {
 	@Override
 	public List<AttributeDTO> getAttributesByGermplasmGUID(
 			final String germplasmGUID, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
-		this.validateGidAndAttributes(germplasmGUID, attributeDbIds);
+		this.validateGuidAndAttributes(germplasmGUID, attributeDbIds);
 		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmGUID);
-		if (germplasmDTO.isPresent()) {
-			return this.germplasmDataManager.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
-		} else {
-			throw new ApiRuntimeException("Invalid Germplasm Id");
-		}
+		return this.germplasmDataManager.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
 	}
 
 	@Override
@@ -460,9 +456,9 @@ public class GermplasmServiceImpl implements GermplasmService {
 		return response;
 	}
 
-	private void validateGidAndAttributes(final String gid, final List<String> attributeDbIds) {
+	private void validateGuidAndAttributes(final String germplasmGUID, final List<String> attributeDbIds) {
 		this.errors = new MapBindingResult(new HashMap<String, String>(), AttributeDTO.class.getName());
-		this.germplasmValidator.validateGermplasmId(this.errors, Integer.valueOf(gid));
+		this.germplasmValidator.validateGermplasmGUID(this.errors, germplasmGUID);
 		if (this.errors.hasErrors()) {
 			throw new ResourceNotFoundException(this.errors.getAllErrors().get(0));
 		}

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -215,7 +215,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 				final int gid = Integer.valueOf(germplasmDto.get().getGid());
 				pedigreeDTO = this.germplasmDataManager.getPedigree(gid, notation, includeSiblings);
 				if (pedigreeDTO != null) {
-					pedigreeDTO.setPedigree(this.pedigreeService.getCrossExpansion(pedigreeDTO.getGermplasmDbId(), this.crossExpansionProperties));
+					pedigreeDTO.setPedigree(this.pedigreeService.getCrossExpansion(gid, this.crossExpansionProperties));
 				}
 			} else {
 				throw new ApiRuntimeException("Invalid Germplasm Id");

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -254,8 +254,8 @@ public class GermplasmServiceImpl implements GermplasmService {
 	}
 
 	@Override
-	public GermplasmDTO getGermplasmDTObyGUID(final String germplasmGUID) {
-		final Optional<GermplasmDTO> germplasmDTOOptional = this.germplasmService.getGermplasmDTOByGUID(germplasmGUID);
+	public GermplasmDTO getGermplasmDTObyGUID(final String germplasmUUID) {
+		final Optional<GermplasmDTO> germplasmDTOOptional = this.germplasmService.getGermplasmDTOByGUID(germplasmUUID);
 		if (germplasmDTOOptional.isPresent()) {
 			final GermplasmDTO germplasmDTO = germplasmDTOOptional.get();
 			germplasmDTO.setPedigree(this.pedigreeService.getCrossExpansion(Integer.valueOf(germplasmDTO.getGid()), this.crossExpansionProperties));
@@ -327,10 +327,10 @@ public class GermplasmServiceImpl implements GermplasmService {
 	}
 
 	@Override
-	public List<AttributeDTO> getAttributesByGermplasmGUID(
-			final String germplasmGUID, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
-		this.validateGuidAndAttributes(germplasmGUID, attributeDbIds);
-		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmGUID);
+	public List<AttributeDTO> getAttributesByGUID(
+			final String germplasmUUID, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
+		this.validateGuidAndAttributes(germplasmUUID, attributeDbIds);
+		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmUUID);
 		if (germplasmDTO.isPresent()) {
 			return this.germplasmDataManager.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
 		} else {
@@ -340,8 +340,13 @@ public class GermplasmServiceImpl implements GermplasmService {
 	}
 
 	@Override
-	public long countAttributesByGermplasmGUID(final String germplasmGUID, final List<String> attributeDbIds) {
-		return this.germplasmDataManager.countAttributesByGid(germplasmGUID, attributeDbIds);
+	public long countAttributesByGUID(final String germplasmUUID, final List<String> attributeDbIds) {
+		final Optional<GermplasmDTO> germplasm = this.germplasmService.getGermplasmDTOByGUID(germplasmUUID);
+		if (germplasm.isPresent()) {
+			return this.germplasmDataManager.countAttributesByGid(germplasm.get().getGid(), attributeDbIds);
+		} else {
+			throw new ApiRuntimeException("Invalid GermplasmDbId");
+		}
 	}
 
 	@Override

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -208,41 +208,23 @@ public class GermplasmServiceImpl implements GermplasmService {
 
 	@Override
 	public PedigreeDTO getPedigree(final String germplasmDbId, final String notation, final Boolean includeSiblings) {
-		final PedigreeDTO pedigreeDTO;
-		try {
-			final Optional<GermplasmDTO> germplasmDto = this.germplasmService.getGermplasmDTOByGUID(germplasmDbId);
-			if (germplasmDto.isPresent()) {
-				final int gid = Integer.valueOf(germplasmDto.get().getGid());
-				pedigreeDTO = this.germplasmService.getPedigree(gid, notation, includeSiblings);
-				if (pedigreeDTO != null) {
-					pedigreeDTO.setPedigree(this.pedigreeService.getCrossExpansion(gid, this.crossExpansionProperties));
-				}
-			} else {
-				throw new ApiRuntimeException("Invalid GermplasmDbId");
-			}
-
-		} catch (final MiddlewareQueryException e) {
-			throw new ApiRuntimeException("An error has occurred when trying to get the pedigree", e);
+		this.errors = new MapBindingResult(new HashMap<String, String>(), GermplasmMatchRequestDto.class.getName());
+		this.germplasmValidator.validateGermplasmGUID(this.errors, germplasmDbId);
+		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmDbId);
+		final int gid = Integer.valueOf(germplasmDTO.get().getGid());
+		final PedigreeDTO pedigreeDTO = this.germplasmService.getPedigree(gid, notation, includeSiblings);
+		if (pedigreeDTO != null) {
+			pedigreeDTO.setPedigree(this.pedigreeService.getCrossExpansion(gid, this.crossExpansionProperties));
 		}
 		return pedigreeDTO;
 	}
 
 	@Override
 	public ProgenyDTO getProgeny(final String germplasmDbId) {
-		final ProgenyDTO progenyDTO;
-		try {
-			final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmDbId);
-			if (germplasmDTO.isPresent()) {
-				final int gid = Integer.valueOf(germplasmDTO.get().getGid());
-				progenyDTO = this.germplasmService.getProgeny(gid);
-			} else {
-				throw new ApiRuntimeException("Invalid GermplasmDbId");
-			}
-
-		} catch (final MiddlewareQueryException e) {
-			throw new ApiRuntimeException("An error has occurred when trying to get the progeny", e);
-		}
-		return progenyDTO;
+		this.errors = new MapBindingResult(new HashMap<String, String>(), GermplasmMatchRequestDto.class.getName());
+		this.germplasmValidator.validateGermplasmGUID(this.errors, germplasmDbId);
+		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmDbId);
+		return this.germplasmService.getProgeny(Integer.valueOf(germplasmDTO.get().getGid()));
 	}
 
 	@Override
@@ -328,25 +310,15 @@ public class GermplasmServiceImpl implements GermplasmService {
 
 	@Override
 	public List<AttributeDTO> getAttributesByGUID(
-			final String germplasmUUID, final List<String> attributeDbIds, final Integer pageSize, final Integer pageNumber) {
+			final String germplasmUUID, final List<String> attributeDbIds, final Pageable pageable) {
 		this.validateGuidAndAttributes(germplasmUUID, attributeDbIds);
-		final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmUUID);
-		if (germplasmDTO.isPresent()) {
-			return this.germplasmService.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
-		} else {
-			throw new ApiRuntimeException("Invalid GermplasmDbId");
-		}
+		return this.germplasmService.getAttributesByGUID(germplasmUUID, attributeDbIds, pageable);
 
 	}
 
 	@Override
 	public long countAttributesByGUID(final String germplasmUUID, final List<String> attributeDbIds) {
-		final Optional<GermplasmDTO> germplasm = this.germplasmService.getGermplasmDTOByGUID(germplasmUUID);
-		if (germplasm.isPresent()) {
-			return this.germplasmService.countAttributesByGid(germplasm.get().getGid(), attributeDbIds);
-		} else {
-			throw new ApiRuntimeException("Invalid GermplasmDbId");
-		}
+		return this.germplasmService.countAttributesByGUID(germplasmUUID, attributeDbIds);
 	}
 
 	@Override

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -218,7 +218,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 					pedigreeDTO.setPedigree(this.pedigreeService.getCrossExpansion(gid, this.crossExpansionProperties));
 				}
 			} else {
-				throw new ApiRuntimeException("Invalid Germplasm Id");
+				throw new ApiRuntimeException("Invalid GermplasmDbId");
 			}
 
 		} catch (final MiddlewareQueryException e) {
@@ -236,7 +236,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 				final int gid = Integer.valueOf(germplasmDTO.get().getGid());
 				progenyDTO = this.germplasmDataManager.getProgeny(gid);
 			} else {
-				throw new ApiRuntimeException("Invalid Germplasm Id");
+				throw new ApiRuntimeException("Invalid GermplasmDbId");
 			}
 
 		} catch (final MiddlewareQueryException e) {
@@ -261,7 +261,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 			germplasmDTO.setPedigree(this.pedigreeService.getCrossExpansion(Integer.valueOf(germplasmDTO.getGid()), this.crossExpansionProperties));
 			return germplasmDTO;
 		} else {
-			throw new ApiRuntimeException("Invalid Germplasm Id");
+			throw new ApiRuntimeException("Invalid GermplasmDbId");
 		}
 
 	}
@@ -334,7 +334,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 		if (germplasmDTO.isPresent()) {
 			return this.germplasmDataManager.getAttributesByGid(germplasmDTO.get().getGid(), attributeDbIds, pageSize, pageNumber);
 		} else {
-			throw new ApiRuntimeException("Invalid Germplasm Id");
+			throw new ApiRuntimeException("Invalid GermplasmDbId");
 		}
 
 	}

--- a/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/germplasm/GermplasmServiceImpl.java
@@ -213,7 +213,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 			final Optional<GermplasmDTO> germplasmDto = this.germplasmService.getGermplasmDTOByGUID(germplasmDbId);
 			if (germplasmDto.isPresent()) {
 				final int gid = Integer.valueOf(germplasmDto.get().getGid());
-				pedigreeDTO = this.germplasmDataManager.getPedigree(gid, notation, includeSiblings);
+				pedigreeDTO = this.germplasmService.getPedigree(gid, notation, includeSiblings);
 				if (pedigreeDTO != null) {
 					pedigreeDTO.setPedigree(this.pedigreeService.getCrossExpansion(gid, this.crossExpansionProperties));
 				}
@@ -234,7 +234,7 @@ public class GermplasmServiceImpl implements GermplasmService {
 			final Optional<GermplasmDTO> germplasmDTO = this.germplasmService.getGermplasmDTOByGUID(germplasmDbId);
 			if (germplasmDTO.isPresent()) {
 				final int gid = Integer.valueOf(germplasmDTO.get().getGid());
-				progenyDTO = this.germplasmDataManager.getProgeny(gid);
+				progenyDTO = this.germplasmService.getProgeny(gid);
 			} else {
 				throw new ApiRuntimeException("Invalid GermplasmDbId");
 			}

--- a/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
+++ b/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
@@ -155,7 +155,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 		final List<AttributeDTO> attributeDTOS = this.createAttributes(germplasmDbId);
 
 		doReturn(attributeDTOS).when(this.germplasmService)
-				.getAttributesByGUID(germplasmDbId, null, new PageRequest(1, BrapiPagedResult.DEFAULT_PAGE_SIZE));
+				.getAttributesByGUID(germplasmDbId, null, new PageRequest(0, BrapiPagedResult.DEFAULT_PAGE_SIZE));
 
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/maize/brapi/v1/germplasm/" + germplasmDbId + "/attributes")
 				.contentType(this.contentType)

--- a/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
+++ b/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
@@ -155,7 +155,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 		final List<AttributeDTO> attributeDTOS = this.createAttributes(germplasmDbId);
 
 		doReturn(attributeDTOS).when(this.germplasmService)
-				.getAttributesByGUID(germplasmDbId, null, BrapiPagedResult.DEFAULT_PAGE_SIZE, 1);
+				.getAttributesByGUID(germplasmDbId, null, new PageRequest(1, BrapiPagedResult.DEFAULT_PAGE_SIZE));
 
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/maize/brapi/v1/germplasm/" + germplasmDbId + "/attributes")
 				.contentType(this.contentType)

--- a/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
+++ b/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
@@ -155,7 +155,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 		final List<AttributeDTO> attributeDTOS = this.createAttributes(germplasmDbId);
 
 		doReturn(attributeDTOS).when(this.germplasmService)
-				.getAttributesByGermplasmGUID(germplasmDbId, null, BrapiPagedResult.DEFAULT_PAGE_SIZE, 1);
+				.getAttributesByGUID(germplasmDbId, null, BrapiPagedResult.DEFAULT_PAGE_SIZE, 1);
 
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/maize/brapi/v1/germplasm/" + germplasmDbId + "/attributes")
 				.contentType(this.contentType)

--- a/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
+++ b/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
@@ -2,6 +2,7 @@ package org.ibp.api.brapi.v1.germplasm;
 
 import com.google.common.collect.Lists;
 import com.jayway.jsonassert.impl.matcher.IsCollectionWithSize;
+import org.apache.commons.lang.RandomStringUtils;
 import org.generationcp.middleware.api.brapi.v1.attribute.AttributeDTO;
 import org.generationcp.middleware.api.brapi.v1.germplasm.GermplasmDTO;
 import org.generationcp.middleware.domain.germplasm.ParentType;
@@ -51,13 +52,13 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 	@Test
 	public void testGetPedigree() throws Exception {
 		final int gid = nextInt();
-		final String germplasmDbId = String.valueOf(gid);
+		final String germplasmDbId = RandomStringUtils.randomAlphabetic(10);
 
 		final PedigreeDTO pedigreeDTO = new PedigreeDTO();
 		pedigreeDTO.setGermplasmDbId(gid);
 		pedigreeDTO.setPedigree(randomAlphanumeric(255));
 
-		doReturn(pedigreeDTO).when(this.germplasmService).getPedigree(gid, null, null);
+		doReturn(pedigreeDTO).when(this.germplasmService).getPedigree(germplasmDbId, null, null);
 
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/maize/brapi/v1/germplasm/" + germplasmDbId + "/pedigree")
 			.contentType(this.contentType)
@@ -71,7 +72,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 	@Test
 	public void testGetProgeny() throws Exception {
 		final int gid = nextInt();
-		final String germplasmDbId = String.valueOf(gid);
+		final String germplasmDbId = RandomStringUtils.randomAlphabetic(10);
 
 		final ProgenyDTO progenyDTO = new ProgenyDTO();
 		progenyDTO.setGermplasmDbId(gid);
@@ -82,7 +83,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 		progenies.add(progeny);
 		progenyDTO.setProgeny(progenies);
 
-		doReturn(progenyDTO).when(this.germplasmService).getProgeny(gid);
+		doReturn(progenyDTO).when(this.germplasmService).getProgeny(germplasmDbId);
 
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/maize/brapi/v1/germplasm/" + germplasmDbId + "/progeny")
 			.contentType(this.contentType)
@@ -154,7 +155,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 		final List<AttributeDTO> attributeDTOS = this.createAttributes(germplasmDbId);
 
 		doReturn(attributeDTOS).when(this.germplasmService)
-				.getAttributesByGid(germplasmDbId, null, BrapiPagedResult.DEFAULT_PAGE_SIZE, 1);
+				.getAttributesByGermplasmGUID(germplasmDbId, null, BrapiPagedResult.DEFAULT_PAGE_SIZE, 1);
 
 		this.mockMvc.perform(MockMvcRequestBuilders.get("/maize/brapi/v1/germplasm/" + germplasmDbId + "/attributes")
 				.contentType(this.contentType)

--- a/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
+++ b/src/test/java/org/ibp/api/brapi/v1/germplasm/GermplasmResourceBrapiTest.java
@@ -55,7 +55,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 		final String germplasmDbId = RandomStringUtils.randomAlphabetic(10);
 
 		final PedigreeDTO pedigreeDTO = new PedigreeDTO();
-		pedigreeDTO.setGermplasmDbId(gid);
+		pedigreeDTO.setGermplasmDbId(String.valueOf(gid));
 		pedigreeDTO.setPedigree(randomAlphanumeric(255));
 
 		doReturn(pedigreeDTO).when(this.germplasmService).getPedigree(germplasmDbId, null, null);
@@ -71,14 +71,14 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 
 	@Test
 	public void testGetProgeny() throws Exception {
-		final int gid = nextInt();
+		final String gid = String.valueOf(nextInt());
 		final String germplasmDbId = RandomStringUtils.randomAlphabetic(10);
 
 		final ProgenyDTO progenyDTO = new ProgenyDTO();
 		progenyDTO.setGermplasmDbId(gid);
 		final List<ProgenyDTO.Progeny> progenies = new ArrayList<>();
 		final ProgenyDTO.Progeny progeny = new ProgenyDTO.Progeny();
-		progeny.setGermplasmDbId(nextInt());
+		progeny.setGermplasmDbId(String.valueOf(nextInt()));
 		progeny.setParentType(ParentType.MALE.name());
 		progenies.add(progeny);
 		progenyDTO.setProgeny(progenies);

--- a/src/test/java/org/ibp/api/brapi/v2/inventory/LotResourceBrapiTest.java
+++ b/src/test/java/org/ibp/api/brapi/v2/inventory/LotResourceBrapiTest.java
@@ -70,6 +70,7 @@ public class LotResourceBrapiTest extends ApiUnitTestBase {
         lotDto1.setGid(random.nextInt(10000));
         lotDto1.setLocationId(random.nextInt(10000));
         lotDto1.setLotId(random.nextInt(10000));
+        lotDto1.setGermplasmUUID(String.valueOf(random.nextInt(1000)));
         list.add(lotDto1);
 
         Mockito.doReturn(list).when(this.lotService).searchLots(Mockito.any(LotsSearchDto.class),
@@ -85,7 +86,7 @@ public class LotResourceBrapiTest extends ApiUnitTestBase {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(jsonPath("$.result.data[0].amount", CoreMatchers.is(lotDto1.getAvailableBalance())))
                 .andExpect(jsonPath("$.result.data[0].createdDate", CoreMatchers.is(timestampFormat.format(lotDto1.getCreatedDate()))))
-                .andExpect(jsonPath("$.result.data[0].germplasmDbId", CoreMatchers.is(lotDto1.getGid())))
+                .andExpect(jsonPath("$.result.data[0].germplasmDbId", CoreMatchers.is(lotDto1.getGermplasmUUID())))
                 .andExpect(jsonPath("$.result.data[0].locationDbId", CoreMatchers.is(lotDto1.getLocationId())))
                 .andExpect(jsonPath("$.result.data[0].seedLotDescription", CoreMatchers.is(lotDto1.getNotes())))
                 .andExpect(jsonPath("$.result.data[0].seedLotName", CoreMatchers.is(lotDto1.getStockId())))

--- a/src/test/java/org/ibp/api/java/impl/middleware/inventory/GermplasmValidatorTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/inventory/GermplasmValidatorTest.java
@@ -1,8 +1,8 @@
 package org.ibp.api.java.impl.middleware.inventory;
 
+import org.generationcp.middleware.api.germplasm.GermplasmService;
 import org.generationcp.middleware.domain.inventory.manager.LotGeneratorInputDto;
 import org.generationcp.middleware.domain.oms.TermId;
-import org.generationcp.middleware.manager.api.GermplasmDataManager;
 import org.generationcp.middleware.pojos.Germplasm;
 import org.hamcrest.CoreMatchers;
 import org.ibp.api.domain.ontology.VariableFilter;
@@ -34,7 +34,7 @@ public class GermplasmValidatorTest {
 	public static final String COMMENTS = "Comments";
 
 	@Mock
-	private GermplasmDataManager germplasmDataManager;
+	private GermplasmService germplasmService;
 
 	@InjectMocks
 	private GermplasmValidator germplasmValidator;
@@ -63,7 +63,7 @@ public class GermplasmValidatorTest {
 		final VariableFilter variableFilter = new VariableFilter();
 		variableFilter.addPropertyId(TermId.INVENTORY_AMOUNT_PROPERTY.getId());
 		final Germplasm germplasm = new Germplasm(GERMPLASM_ID);
-		Mockito.when(this.germplasmDataManager.getGermplasmByGID(GERMPLASM_ID)).thenReturn(germplasm);
+		Mockito.when(this.germplasmService.getGermplasmByGIDs(Arrays.asList(GERMPLASM_ID))).thenReturn(Arrays.asList(germplasm));
 		this.germplasmValidator.validateGermplasmId(this.errors, GERMPLASM_ID);
 
 		Assert.assertEquals(this.errors.getAllErrors().size(), 0);
@@ -102,7 +102,7 @@ public class GermplasmValidatorTest {
 		this.lotGeneratorInputDto.setNotes(COMMENTS);
 		final VariableFilter variableFilter = new VariableFilter();
 		variableFilter.addPropertyId(TermId.INVENTORY_AMOUNT_PROPERTY.getId());
-		Mockito.when(this.germplasmDataManager.getGermplasmByGID(GERMPLASM_ID)).thenReturn(null);
+		Mockito.when(this.germplasmService.getGermplasmByGIDs(Arrays.asList(GERMPLASM_ID))).thenReturn(null);
 		this.germplasmValidator.validateGermplasmId(this.errors, GERMPLASM_ID);
 
 		Assert.assertEquals(this.errors.getAllErrors().size(),  1);
@@ -114,7 +114,7 @@ public class GermplasmValidatorTest {
 	public void testValidateGermplasmListInvalid() {
 		this.errors = new MapBindingResult(new HashMap<String, String>(), LotGeneratorInputDto.class.getName());
 		final List<Integer> gids = Collections.singletonList(GERMPLASM_ID);
-		Mockito.when(this.germplasmDataManager.getGermplasms(gids)).thenReturn(Collections.EMPTY_LIST);
+		Mockito.when(this.germplasmService.getGermplasmByGIDs(gids)).thenReturn(Collections.EMPTY_LIST);
 
 		try {
 			this.germplasmValidator.validateGids(this.errors, gids);

--- a/src/test/java/org/ibp/api/java/impl/middleware/inventory/TransactionServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/inventory/TransactionServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.ibp.api.java.impl.middleware.inventory;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.generationcp.middleware.domain.inventory.common.SearchCompositeDto;
 import org.generationcp.middleware.domain.inventory.manager.ExtendedLotDto;
 import org.generationcp.middleware.domain.inventory.manager.LotDepositRequestDto;
@@ -66,7 +67,7 @@ public class TransactionServiceImplTest {
 	public void testGetTransactions() {
 		final TransactionDto transactionDto = new TransactionDto(1, "admin", TransactionType.DEPOSIT.name(), new Double(1),new Double(0),
 			"comments", new Date(), 1, "1de85e1c-b947-4ee2-9d19-31eee6da9ad5", 1, "desig", "STOCK-1", 8314, "SEED_AMOUNT_g",
-			LotStatus.ACTIVE.name(), TransactionStatus.CONFIRMED.getValue(), 0, "UNKNOWN", "UNKNOWN", "comments");
+			LotStatus.ACTIVE.name(), TransactionStatus.CONFIRMED.getValue(), 0, "UNKNOWN", "UNKNOWN", "comments", RandomStringUtils.randomAlphanumeric(10));
 		Mockito.when(this.transactionService.searchTransactions(ArgumentMatchers.any(TransactionsSearchDto.class), ArgumentMatchers.any(
 			Pageable.class))).thenReturn(Collections.singletonList(transactionDto));
 		final Pageable pageable = Mockito.mock(Pageable.class);

--- a/src/test/java/org/ibp/api/java/impl/middleware/inventory/TransactionServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/inventory/TransactionServiceImplTest.java
@@ -86,7 +86,7 @@ public class TransactionServiceImplTest {
 		Assert.assertEquals(transactionDto.getTransactionType(), additionalInfo.get("transactionType"));
 		Assert.assertEquals(transactionDto.getTransactionStatus(), additionalInfo.get("transactionStatus"));
 		Assert.assertEquals(transactionDto.getLot().getLotUUID(), additionalInfo.get("seedLotID"));
-		Assert.assertEquals(transactionDto.getLot().getGid(), additionalInfo.get("germplasmDbId"));
+		Assert.assertEquals(transactionDto.getLot().getGermplasmUUID(), additionalInfo.get("germplasmDbId"));
 		Assert.assertEquals(transactionDto.getLot().getLocationId(), additionalInfo.get("locationId"));
 		Assert.assertEquals(transactionDto.getLot().getLocationName(), additionalInfo.get("locationName"));
 		Assert.assertEquals(transactionDto.getLot().getLocationAbbr(), additionalInfo.get("locationAbbr"));


### PR DESCRIPTION
Remove converting value of germplasmDbId to integer, value is string and equivalent to germplasmDbId
Apply changes in services w/c uses gid for filtering 
Some changes may affect datamanager, upon checking method only uses in brapi calls (in affected endpoints)