### PR TITLE
 IBP-2634-FixFailingUnitTests

### DIFF
--- a/src/test/java/org/ibp/api/java/impl/middleware/dataset/DatasetCSVExportServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/dataset/DatasetCSVExportServiceImplTest.java
@@ -49,6 +49,7 @@ import java.util.Set;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyListOf;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -146,7 +147,7 @@ public class DatasetCSVExportServiceImplTest {
 
 		final File zipFile = new File("");
 		final Set<Integer> instanceIds = new HashSet<>(Arrays.asList(this.instanceId1, this.instanceId2));
-		when(this.zipUtil.zipFiles(eq(FileNameGenerator.generateFileName(this.study.getName())), anyListOf(File.class))).thenReturn(zipFile);
+		when(this.zipUtil.zipFiles(contains(this.study.getName()), anyListOf(File.class))).thenReturn(zipFile);
 		final Map<Integer, List<ObservationUnitRow>> instanceObservationUnitRowsMap = Mockito.mock(HashMap.class);
 		when(this.studyDatasetService
 			.getInstanceObservationUnitRowsMap(eq(this.study.getId()), eq(this.dataSetDTO.getDatasetId()), any(ArrayList.class)))
@@ -176,7 +177,7 @@ public class DatasetCSVExportServiceImplTest {
 		when(this.datasetCSVGenerator.generateSingleInstanceFile(anyInt(), eq(this.dataSetDTO), eq(measurementVariables),
 			ArgumentMatchers.anyList(), anyString(), any(StudyInstance.class)))
 			.thenReturn(new File(""));
-		when(this.zipUtil.zipFiles(eq(FileNameGenerator.generateFileName(this.study.getName())), anyListOf(File.class))).thenReturn(zipFile);
+		when(this.zipUtil.zipFiles(contains(this.study.getName()), anyListOf(File.class))).thenReturn(zipFile);
 		this.datasetExportService.setZipUtil(this.zipUtil);
 
 		final Map<Integer, StudyInstance> studyInstanceMap = this.datasetExportService

--- a/src/test/java/org/ibp/api/java/impl/middleware/dataset/DatasetExcelExportServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/dataset/DatasetExcelExportServiceImplTest.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import static org.junit.Assert.assertSame;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyListOf;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -127,7 +128,7 @@ public class DatasetExcelExportServiceImplTest {
 
 		final File zipFile = new File("");
 		final Set<Integer> instanceIds = new HashSet<>(Arrays.asList(this.instanceId1, this.instanceId2));
-		when(this.zipUtil.zipFiles(eq(FileNameGenerator.generateFileName(this.study.getName())), anyListOf(File.class))).thenReturn(zipFile);
+		when(this.zipUtil.zipFiles(contains(this.study.getName()), anyListOf(File.class))).thenReturn(zipFile);
 		Mockito.when(this.datasetExportService.getColumns(this.study.getId(), this.dataSetDTO.getDatasetId()))
 			.thenReturn(this.measurementVariables);
 		final File result = this.datasetExportService.export(this.study.getId(), this.dataSetDTO.getDatasetId(), instanceIds,
@@ -149,7 +150,7 @@ public class DatasetExcelExportServiceImplTest {
 		when(this.datasetExcelGenerator.generateSingleInstanceFile(anyInt(), eq(this.dataSetDTO), eq(measurementVariables),
 			ArgumentMatchers.<ObservationUnitRow>anyList(), anyString(), any(StudyInstance.class)))
 			.thenReturn(new File(""));
-		when(this.zipUtil.zipFiles(eq(FileNameGenerator.generateFileName(this.study.getName())), anyListOf(File.class))).thenReturn(zipFile);
+		when(this.zipUtil.zipFiles(contains(this.study.getName()), anyListOf(File.class))).thenReturn(zipFile);
 		this.datasetExportService.setZipUtil(this.zipUtil);
 
 		final Map<Integer, StudyInstance> studyInstanceMap = this.datasetExportService
@@ -167,7 +168,7 @@ public class DatasetExcelExportServiceImplTest {
 				anyInt(), eq(this.dataSetDTO), eq(measurementVariables), ArgumentMatchers.<ObservationUnitRow>anyList(), anyString(),
 				any(StudyInstance.class));
 
-		verify(this.zipUtil).zipFiles(eq(FileNameGenerator.generateFileName(this.study.getName())), anyListOf(File.class));
+		verify(this.zipUtil).zipFiles(contains(this.study.getName()), anyListOf(File.class));
 		assertSame(result, zipFile);
 	}
 

--- a/src/test/java/org/ibp/api/java/impl/middleware/dataset/DatasetKsuExportServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/dataset/DatasetKsuExportServiceImplTest.java
@@ -1,7 +1,6 @@
 package org.ibp.api.java.impl.middleware.dataset;
 
 import com.google.common.collect.Lists;
-import org.generationcp.commons.util.FileNameGenerator;
 import org.generationcp.commons.util.ZipUtil;
 import org.generationcp.middleware.data.initializer.DatasetTypeTestDataInitializer;
 import org.generationcp.middleware.data.initializer.MeasurementVariableTestDataInitializer;
@@ -54,6 +53,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyListOf;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -157,7 +157,7 @@ public class DatasetKsuExportServiceImplTest {
 
 		final File zipFile = new File("");
 		final Set<Integer> instanceIds = new HashSet<>(Arrays.asList(instanceId1, instanceId2));
-		when(this.zipUtil.zipFiles(eq(FileNameGenerator.generateFileName(study.getName())), anyListOf(File.class))).thenReturn(zipFile);
+		when(this.zipUtil.zipFiles(contains(study.getName()), anyListOf(File.class))).thenReturn(zipFile);
 		final Map<Integer, List<ObservationUnitRow>> instanceObservationUnitRowsMap = new HashMap<>();
 		instanceObservationUnitRowsMap.put(1, new ArrayList<>());
 		instanceObservationUnitRowsMap.put(2, new ArrayList<>());

--- a/src/test/java/org/ibp/api/java/impl/middleware/study/StudyEntryServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/study/StudyEntryServiceImplTest.java
@@ -333,14 +333,9 @@ public class StudyEntryServiceImplTest {
 			.thenReturn(datasetDTOS);
 		Mockito.when(this.middlewareStudyEntryService.saveStudyEntries(ArgumentMatchers.eq(studyId), ArgumentMatchers.anyList())).thenReturn(entryDtos);
 
-		try {
-			final List<StudyEntryDto> studyEntryDtos = this.studyEntryService.createStudyEntries(studyId, germplasmListId);
-			Assert.assertNotNull("Duplicate gid in list should be accepted. ", studyEntryDtos);
-			org.junit.Assert.assertEquals("Must return same germplasm list data count", listData.size(),studyEntryDtos.size());
-		} catch (final Exception e) {
-			org.junit.Assert.fail("Duplicate gid in list should be accepted, no exception");
-		}
-
+		final List<StudyEntryDto> studyEntryDtos = this.studyEntryService.createStudyEntries(studyId, germplasmListId);
+		Assert.assertNotNull("Duplicate gid in list should be accepted. ", studyEntryDtos);
+		org.junit.Assert.assertEquals("Must return same germplasm list data count", listData.size(),studyEntryDtos.size());
 		Mockito.verify(this.germplasmListValidator).validateGermplasmList(germplasmListId);
 		Mockito.verify(this.studyValidator).validate(studyId, true);
 		Mockito.verify(this.studyEntryValidator).validateStudyAlreadyHasStudyEntries(studyId);
@@ -353,30 +348,19 @@ public class StudyEntryServiceImplTest {
 		final GermplasmListData data1 = new GermplasmListData();
 		data1.setGermplasm(germplasm);
 		data1.setGid(germplasm.getGid());
-		data1.setEntryId(this.randomEntryId());
+		data1.setEntryId(1);
 		data1.setEntryCode(StringUtils.randomAlphanumeric(3));
 
 		final GermplasmListData data2 = new GermplasmListData();
 		data2.setGermplasm(germplasm);
 		data2.setGid(germplasm.getGid());
-		data2.setEntryId(this.randomEntryId());
+		data2.setEntryId(2);
 		data2.setEntryCode(StringUtils.randomAlphanumeric(3));
 
 		final List<GermplasmListData> listData = new ArrayList<>();
 		listData.add(data1);
 		listData.add(data2);
 		return listData;
-	}
-
-	private int randomEntryId() {
-		int entryId;
-		try {
-			final double random = Math.random() * 100;
-			entryId = (int) random;
-		} catch (final Exception e) {
-			entryId = 1;
-		}
-		return entryId;
 	}
 
 }


### PR DESCRIPTION
zipUtil.zipFiles : Filename contains timestamp, causing when mock
StudyEntry: Use hardcoded entryId remove catch exception
Affected Tests 
DatasetCSVExportServiceImplTest.testExport 
DatasetCSVExportServiceImplTest.testGenerateCSVFilesMoreThanOneInstance 
DatasetExcelExportServiceImplTest.testExport
DatasetExcelExportServiceImplTest.testGenerateExcelFilesMoreThanOneInstance 
DatasetKsuExportServiceImplTest.testGenerateForKSUExcel 
DatasetKsuExportServiceImplTest.testGenerateForKSUCSV
StudyEntryServiceImplTest.testCreateStudyGermplasmListDuplicateEntries 