### PR TITLE
IBP-4506 /brapi/v2/token shortcut

### DIFF
--- a/src/main/java/org/ibp/api/brapi/v1/security/auth/AuthenticationControllerBrapi.java
+++ b/src/main/java/org/ibp/api/brapi/v1/security/auth/AuthenticationControllerBrapi.java
@@ -46,7 +46,7 @@ public class AuthenticationControllerBrapi {
 	private UserDetailsService userDetailsService;
 
 	@ApiOperation(value = "Get token")
-	@RequestMapping(value = {"/brapi/v1/token", "/token"}, method = RequestMethod.POST)
+	@RequestMapping(value = {"/brapi/v1/token", "/brapi/v2/token", "/token"}, method = RequestMethod.POST)
 	@ResponseBody
 	public TokenResponse authenticate(@RequestBody final TokenRequest tokenRequest) {
 		final String username = tokenRequest.getUsername();


### PR DESCRIPTION
Makes it easy to use the same base url for all v2 calls (some external
tools may still rely on this, though we are moving to more standard
authorization schemes).