### PR TITLE
IBP-4476-PRepDesignNonReplicatedEntries

### DIFF
--- a/src/main/java/org/ibp/api/java/impl/middleware/design/type/PRepDesignTypeServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/design/type/PRepDesignTypeServiceImpl.java
@@ -112,7 +112,7 @@ public class PRepDesignTypeServiceImpl implements ExperimentalDesignTypeService 
 
 		for (final StudyEntryDto studyEntryDto : studyEntryDtoList) {
 			final Optional<String> entryType = studyEntryDto.getStudyEntryPropertyValue(TermId.ENTRY_TYPE.getId());
-			if (entryType.isPresent() && SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId() == Integer.valueOf(entryType.get())) {
+			if (entryType.isPresent() && SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId() == Integer.parseInt(entryType.get())) {
 				testEntryCount++;
 				testEntryNumbers.add(studyEntryDto.getEntryNumber());
 			}
@@ -126,10 +126,11 @@ public class PRepDesignTypeServiceImpl implements ExperimentalDesignTypeService 
 			randomTestEntryNumbers.add(testEntryNumbers.get(new Random().nextInt(testEntryNumbers.size())));
 		}
 
+
 		final List<ListItem> replicationListItem = new LinkedList<>();
 		for (final StudyEntryDto studyEntryDto : studyEntryDtoList) {
 			final Optional<String> entryType = studyEntryDto.getStudyEntryPropertyValue(TermId.ENTRY_TYPE.getId());
-			if (entryType.isPresent() && SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId() != Integer.valueOf(entryType.get())) {
+			if (entryType.isPresent() && !this.isTestEntry(entryType.get()) && !this.isNonReplicatedEntry(entryType.get())) {
 				// All Check Entries in the list should be replicated
 				replicationListItem.add(new ListItem(String.valueOf(replicationNumber)));
 			} else if (randomTestEntryNumbers.contains(studyEntryDto.getEntryNumber())) {
@@ -143,4 +144,13 @@ public class PRepDesignTypeServiceImpl implements ExperimentalDesignTypeService 
 
 		return Collections.singletonMap(BreedingViewDesignParameter.NREPEATS, replicationListItem);
 	}
+
+	private boolean isTestEntry(final String entryType) {
+	  return SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId() == Integer.parseInt(entryType);
+	}
+
+  private boolean isNonReplicatedEntry(final String entryType) {
+	return SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId() == Integer.parseInt(entryType);
+  }
+
 }

--- a/src/main/java/org/ibp/api/java/impl/middleware/study/StudyEntryMetadata.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/study/StudyEntryMetadata.java
@@ -12,6 +12,8 @@ public class StudyEntryMetadata {
 
 	private Long nonTestEntriesCount;
 
+	private Long nonReplicatedEntriesCount;
+
 	private Boolean hasUnassignedEntries;
 
 	public Long getTestEntriesCount() {
@@ -46,7 +48,15 @@ public class StudyEntryMetadata {
 		this.hasUnassignedEntries = hasUnassignedEntries;
 	}
 
-	@Override
+  public Long getNonReplicatedEntriesCount() {
+	return nonReplicatedEntriesCount;
+  }
+
+  public void setNonReplicatedEntriesCount(final Long nonReplicatedEntriesCount) {
+	this.nonReplicatedEntriesCount = nonReplicatedEntriesCount;
+  }
+
+  @Override
 	public int hashCode() {
 		return Pojomatic.hashCode(this);
 	}

--- a/src/main/java/org/ibp/api/java/impl/middleware/study/StudyEntryServiceImpl.java
+++ b/src/main/java/org/ibp/api/java/impl/middleware/study/StudyEntryServiceImpl.java
@@ -267,7 +267,12 @@ public class StudyEntryServiceImpl implements StudyEntryService {
 		}
 	}
 
-	@Override
+  @Override public long countAllNonReplicatedTestEntries(final Integer studyId) {
+	return this.middlewareStudyEntryService.countStudyGermplasmByEntryTypeIds(studyId,
+			Collections.singletonList(String.valueOf(SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId())));
+  }
+
+  @Override
 	public StudyEntryMetadata getStudyEntriesMetadata(final Integer studyId, final String programUuid) {
 		this.studyValidator.validate(studyId, false);
 		final StudyEntryMetadata studyEntryMetadata = new StudyEntryMetadata();
@@ -275,6 +280,7 @@ public class StudyEntryServiceImpl implements StudyEntryService {
 		studyEntryMetadata.setCheckEntriesCount(this.countAllCheckTestEntries(studyId, programUuid, true));
 		studyEntryMetadata.setNonTestEntriesCount(this.countAllCheckTestEntries(studyId, programUuid, false));
 		studyEntryMetadata.setHasUnassignedEntries(this.middlewareStudyEntryService.hasUnassignedEntries(studyId));
+		studyEntryMetadata.setNonReplicatedEntriesCount(this.countAllNonReplicatedTestEntries(studyId));
 		return studyEntryMetadata;
 	}
 

--- a/src/main/java/org/ibp/api/java/study/StudyEntryService.java
+++ b/src/main/java/org/ibp/api/java/study/StudyEntryService.java
@@ -32,6 +32,8 @@ public interface StudyEntryService {
 
 	long countAllCheckTestEntries(Integer studyId, String programUuid, Boolean checkOnly);
 
+	long countAllNonReplicatedTestEntries(Integer studyId);
+
 	StudyEntryMetadata getStudyEntriesMetadata(Integer studyId, String programUuid);
 
 	List<MeasurementVariable> getEntryDescriptorColumns(Integer studyId);

--- a/src/test/java/org/ibp/api/java/impl/middleware/design/type/PRepDesignTypeServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/design/type/PRepDesignTypeServiceImplTest.java
@@ -213,6 +213,43 @@ public class PRepDesignTypeServiceImplTest {
 
 	}
 
+	@Test
+	public void testCreateReplicationListItemForPRepDesignWithSystemDefinedNonReplicatedEntryType() {
+
+		final int noOfTestEntries = 4;
+		final int noOfCheckEntries = 2;
+		final int noOfNonReplicatedEntries = 20;
+		final int replicationNumber = 3;
+		final float replicationPercentage = 100.0f;
+		final float noOfTestEntriesToReplicate = Math.round((float) noOfTestEntries * (replicationPercentage / 100));
+
+		final List<StudyEntryDto> importedGermplasmList = StudyEntryTestDataGenerator.createStudyEntryDtoList(noOfTestEntries, noOfCheckEntries, noOfNonReplicatedEntries);
+
+		// Set the first germplasm as CHECK_ENTRY.
+		final StudyEntryDto checkImportedGermplasm = importedGermplasmList.get(0);
+		checkImportedGermplasm.getProperties().get(TermId.ENTRY_TYPE.getId()).setValue(String.valueOf(SystemDefinedEntryType.CHECK_ENTRY.getEntryTypeCategoricalId()));
+
+		final Map<BreedingViewDesignParameter, List<ListItem>> map =
+				this.designTypeService
+						.createReplicationListItems(importedGermplasmList, replicationPercentage, replicationNumber);
+
+		Assert.assertNotNull(map);
+		Assert.assertEquals(1, map.size());
+		Assert.assertNotNull(map.get(BreedingViewDesignParameter.NREPEATS));
+
+		float countOfReplicatedListItem = 0;
+		for (final ListItem listItem : map.get(BreedingViewDesignParameter.NREPEATS)) {
+			if (listItem.getValue().equals(String.valueOf(replicationNumber))) {
+				countOfReplicatedListItem++;
+			}
+		}
+
+		Assert.assertEquals("Non Replicated Entries are not included from countReplicatedListITem",
+				String.valueOf(countOfReplicatedListItem), String.valueOf((noOfTestEntriesToReplicate + noOfCheckEntries)));
+		Assert.assertEquals(26,map.get(BreedingViewDesignParameter.NREPEATS).size());
+	}
+
+
 	private List<StandardVariable> createTestStandardVariables() {
 		final List<StandardVariable> standardVariables = new ArrayList<>();
 		standardVariables.add(StandardVariableTestDataInitializer.createStandardVariable(TermId.ENTRY_NO.getId(), ENTRY_NO));

--- a/src/test/java/org/ibp/api/java/impl/middleware/design/type/PRepDesignTypeServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/design/type/PRepDesignTypeServiceImplTest.java
@@ -218,12 +218,12 @@ public class PRepDesignTypeServiceImplTest {
 
 		final int noOfTestEntries = 4;
 		final int noOfCheckEntries = 2;
-		final int noOfNonReplicatedEntries = 20;
+		final int nonReplicatedEntriesCount = 20;
 		final int replicationNumber = 3;
 		final float replicationPercentage = 100.0f;
 		final float noOfTestEntriesToReplicate = Math.round((float) noOfTestEntries * (replicationPercentage / 100));
 
-		final List<StudyEntryDto> importedGermplasmList = StudyEntryTestDataGenerator.createStudyEntryDtoList(noOfTestEntries, noOfCheckEntries, noOfNonReplicatedEntries);
+		final List<StudyEntryDto> importedGermplasmList = StudyEntryTestDataGenerator.createStudyEntryDtoList(noOfTestEntries, noOfCheckEntries, nonReplicatedEntriesCount);
 
 		// Set the first germplasm as CHECK_ENTRY.
 		final StudyEntryDto checkImportedGermplasm = importedGermplasmList.get(0);

--- a/src/test/java/org/ibp/api/java/impl/middleware/design/type/StudyEntryTestDataGenerator.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/design/type/StudyEntryTestDataGenerator.java
@@ -46,4 +46,28 @@ public abstract class StudyEntryTestDataGenerator {
 		return studyEntryDto;
 	}
 
+	public static List<StudyEntryDto> createStudyEntryDtoList(final int numberOfTestEntries, final int numberOfCheckEntries, final int numberOfNonReplicatedEntries) {
+		final List<StudyEntryDto> studyEntryDtoList = new ArrayList<>();
+
+		int entryNumber = 1;
+		int germplasmId = 100;
+		for (int i = 1; i <= numberOfCheckEntries; i++) {
+			studyEntryDtoList.add(createStudyEntry(entryNumber, germplasmId, SystemDefinedEntryType.CHECK_ENTRY));
+			entryNumber++;
+			germplasmId++;
+		}
+		for (int i = 1; i <= numberOfTestEntries; i++) {
+			studyEntryDtoList.add(createStudyEntry(entryNumber, germplasmId, SystemDefinedEntryType.TEST_ENTRY));
+			entryNumber++;
+			germplasmId++;
+		}
+
+		for (int i = 1; i <= numberOfNonReplicatedEntries; i++) {
+			studyEntryDtoList.add(createStudyEntry(entryNumber, germplasmId, SystemDefinedEntryType.NON_REPLICATED_ENTRY));
+			entryNumber++;
+			germplasmId++;
+		}
+		return studyEntryDtoList;
+	}
+
 }

--- a/src/test/java/org/ibp/api/java/impl/middleware/design/type/StudyEntryTestDataGenerator.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/design/type/StudyEntryTestDataGenerator.java
@@ -46,7 +46,7 @@ public abstract class StudyEntryTestDataGenerator {
 		return studyEntryDto;
 	}
 
-	public static List<StudyEntryDto> createStudyEntryDtoList(final int numberOfTestEntries, final int numberOfCheckEntries, final int numberOfNonReplicatedEntries) {
+	public static List<StudyEntryDto> createStudyEntryDtoList(final int numberOfTestEntries, final int numberOfCheckEntries, final int nonReplicatedEntriesCount) {
 		final List<StudyEntryDto> studyEntryDtoList = new ArrayList<>();
 
 		int entryNumber = 1;
@@ -62,7 +62,7 @@ public abstract class StudyEntryTestDataGenerator {
 			germplasmId++;
 		}
 
-		for (int i = 1; i <= numberOfNonReplicatedEntries; i++) {
+		for (int i = 1; i <= nonReplicatedEntriesCount; i++) {
 			studyEntryDtoList.add(createStudyEntry(entryNumber, germplasmId, SystemDefinedEntryType.NON_REPLICATED_ENTRY));
 			entryNumber++;
 			germplasmId++;

--- a/src/test/java/org/ibp/api/java/impl/middleware/study/StudyEntryServiceImplTest.java
+++ b/src/test/java/org/ibp/api/java/impl/middleware/study/StudyEntryServiceImplTest.java
@@ -205,6 +205,7 @@ public class StudyEntryServiceImplTest {
 		final Long testEntriesCount = Long.valueOf(5);
 		final Long checkEntriesCount = Long.valueOf(3);
 		final Long nonTestEntriesCount = Long.valueOf(2);
+		final Long nonReplicatedEntriesCount = Long.valueOf(3);
 
 		Mockito.when(this.middlewareStudyEntryService.countStudyGermplasmByEntryTypeIds(studyId,
 			Collections.singletonList(String.valueOf(SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId()))))
@@ -212,6 +213,9 @@ public class StudyEntryServiceImplTest {
 		Mockito.when(this.middlewareStudyEntryService.countStudyGermplasmByEntryTypeIds(studyId,
 			Collections.singletonList(String.valueOf(SystemDefinedEntryType.CHECK_ENTRY.getEntryTypeCategoricalId()))))
 			.thenReturn(checkEntriesCount);
+		Mockito.when(this.middlewareStudyEntryService.countStudyGermplasmByEntryTypeIds(studyId,
+				Collections.singletonList(String.valueOf(SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId()))))
+				.thenReturn(nonReplicatedEntriesCount);
 
 		final List<Enumeration> enumerations = new ArrayList<>();
 		enumerations.add(new Enumeration(SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId(),
@@ -220,19 +224,30 @@ public class StudyEntryServiceImplTest {
 			SystemDefinedEntryType.CHECK_ENTRY.getEntryTypeName(),SystemDefinedEntryType.CHECK_ENTRY.getEntryTypeValue(), 2));
 		enumerations.add(new Enumeration(SystemDefinedEntryType.DISEASE_CHECK.getEntryTypeCategoricalId(),
 			SystemDefinedEntryType.DISEASE_CHECK.getEntryTypeName(),SystemDefinedEntryType.DISEASE_CHECK.getEntryTypeValue(), 3));
+		enumerations.add(new Enumeration(SystemDefinedEntryType.DISEASE_CHECK.getEntryTypeCategoricalId(),
+				SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeName(),SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeValue(), 4));
+
 		Mockito.when(this.entryTypeService.getEntryTypes(programUUID)).thenReturn(enumerations);
 
 		final List<String> checkEntryTypeIds = enumerations.stream()
 			.filter(entryType -> entryType.getId() != SystemDefinedEntryType.TEST_ENTRY.getEntryTypeCategoricalId())
 			.map(entryType -> String.valueOf(entryType.getId())).collect(Collectors.toList());
+
+		final List<String> nonReplicatedEntryTypeIds = enumerations.stream()
+				.filter(entryType -> entryType.getId() == SystemDefinedEntryType.NON_REPLICATED_ENTRY.getEntryTypeCategoricalId())
+				.map(entryType -> String.valueOf(entryType.getId())).collect(Collectors.toList());
+
+
 		Mockito.when(this.middlewareStudyEntryService
 			.countStudyGermplasmByEntryTypeIds(studyId, checkEntryTypeIds)).thenReturn(nonTestEntriesCount);
 		Mockito.when(this.middlewareStudyEntryService.hasUnassignedEntries(studyId)).thenReturn(false);
+
 
 		final StudyEntryMetadata metadata = this.studyEntryService.getStudyEntriesMetadata(studyId, programUUID);
 		Assert.assertEquals(testEntriesCount, metadata.getTestEntriesCount());
 		Assert.assertEquals(checkEntriesCount, metadata.getCheckEntriesCount());
 		Assert.assertEquals(nonTestEntriesCount, metadata.getNonTestEntriesCount());
+		Assert.assertEquals(nonReplicatedEntriesCount, metadata.getNonReplicatedEntriesCount());
 		Assert.assertFalse(metadata.getHasUnassignedEntries());
 	}
 


### PR DESCRIPTION
Added condition when creating replicationItemList. Only set replication number if entrytype is not test and not non-replicated items. 
Field for nonReplicatedEntriesCount in StudyEntryMetadata 
Unit test for create replication item list and studyEntryService