### PR TITLE
IBP-4878 Remove AppLauncherService

### DIFF
--- a/src/test/java/org/ibp/api/brapi/v2/program/ProgramResourceBrapiv2Test.java
+++ b/src/test/java/org/ibp/api/brapi/v2/program/ProgramResourceBrapiv2Test.java
@@ -205,7 +205,7 @@ public class ProgramResourceBrapiv2Test extends ApiUnitTestBase {
 
 	@Test
 	public void testListProgramFilterByAbbreviation() throws Exception {
-		Mockito.when(this.workbenchDataManager.countProjectsByFilter(org.mockito.Matchers.any(ProgramSearchRequest.class)))
+		Mockito.when(this.programService.countProgramsByFilter(org.mockito.Matchers.any(ProgramSearchRequest.class)))
 			.thenReturn(1L);
 
 		final UriComponents uriComponents = UriComponentsBuilder.newInstance().path(ProgramResourceBrapiv2Test.BRAPI_V2_PROGRAMS)

--- a/src/test/java/org/ibp/api/brapi/v2/program/ProgramResourceBrapiv2Test.java
+++ b/src/test/java/org/ibp/api/brapi/v2/program/ProgramResourceBrapiv2Test.java
@@ -204,6 +204,20 @@ public class ProgramResourceBrapiv2Test extends ApiUnitTestBase {
 	}
 
 	@Test
+	public void testListProgramFilterByAbbreviation() throws Exception {
+		Mockito.when(this.workbenchDataManager.countProjectsByFilter(org.mockito.Matchers.any(ProgramSearchRequest.class)))
+			.thenReturn(1L);
+
+		final UriComponents uriComponents = UriComponentsBuilder.newInstance().path(ProgramResourceBrapiv2Test.BRAPI_V2_PROGRAMS)
+			.queryParam("abbreviation", "AAAB").build().encode();
+		this.mockMvc.perform(MockMvcRequestBuilders.get(uriComponents.toString()).contentType(this.contentType)) //
+			.andExpect(MockMvcResultMatchers.status().isNotImplemented()) //
+			.andDo(MockMvcResultHandlers.print()) //
+			.andExpect(MockMvcResultMatchers.jsonPath("$.metadata.status[0].message", Matchers.is("Abbreviation is not yet supported")));
+
+	}
+
+	@Test
 	public void testListProgramFilterByProgramId() throws Exception {
 		Mockito.when(this.programService.countProgramsByFilter(org.mockito.Matchers.any(ProgramSearchRequest.class)))
 			.thenReturn(1L);

--- a/src/test/java/org/ibp/api/brapi/v2/program/ProgramResourceBrapiv2Test.java
+++ b/src/test/java/org/ibp/api/brapi/v2/program/ProgramResourceBrapiv2Test.java
@@ -204,20 +204,6 @@ public class ProgramResourceBrapiv2Test extends ApiUnitTestBase {
 	}
 
 	@Test
-	public void testListProgramFilterByAbbreviation() throws Exception {
-		Mockito.when(this.workbenchDataManager.countProjectsByFilter(org.mockito.Matchers.any(ProgramSearchRequest.class)))
-			.thenReturn(1L);
-
-		final UriComponents uriComponents = UriComponentsBuilder.newInstance().path(ProgramResourceBrapiv2Test.BRAPI_V2_PROGRAMS)
-			.queryParam("abbreviation", "AAAB").build().encode();
-		this.mockMvc.perform(MockMvcRequestBuilders.get(uriComponents.toString()).contentType(this.contentType)) //
-			.andExpect(MockMvcResultMatchers.status().isNotImplemented()) //
-			.andDo(MockMvcResultHandlers.print()) //
-			.andExpect(MockMvcResultMatchers.jsonPath("$.metadata.status[0].message", Matchers.is("Abbreviation is not yet supported")));
-
-	}
-
-	@Test
 	public void testListProgramFilterByProgramId() throws Exception {
 		Mockito.when(this.programService.countProgramsByFilter(org.mockito.Matchers.any(ProgramSearchRequest.class)))
 			.thenReturn(1L);


### PR DESCRIPTION
 As a part of removing the AppLauncherService implementation.

* Removed unnecessary properties.
* Removed unnecessary tests.
* Removed methods from WorkbenchDataManager without use.

Included:
https://github.com/IntegratedBreedingPlatform/Middleware/pull/1132
https://github.com/IntegratedBreedingPlatform/Workbench/pull/545

Please, review