### PR TITLE
IBP-5072: align attribute names to brapi specs

### DIFF
--- a/src/main/java/org/ibp/api/brapi/v1/germplasm/Germplasm.java
+++ b/src/main/java/org/ibp/api/brapi/v1/germplasm/Germplasm.java
@@ -60,6 +60,7 @@ public class Germplasm {
 
 	private String countryOfOriginCode;
 
+	@JsonView({BrapiView.BrapiV1_2.class, BrapiView.BrapiV1_3.class})
 	private List<String> typeOfGermplasmStorageCode = new ArrayList<>();
 
 	@JsonView({BrapiView.BrapiV1_2.class, BrapiView.BrapiV2.class})
@@ -118,7 +119,7 @@ public class Germplasm {
 	private List<ExternalReferenceDTO> externalReferences;
 
 	@JsonView(BrapiView.BrapiV2.class)
-	private List<String> storageTypes;
+	private List<String> storageTypes = new ArrayList<>();
 
 	public Germplasm() {
 	}

--- a/src/main/java/org/ibp/api/domain/search/SearchDto.java
+++ b/src/main/java/org/ibp/api/domain/search/SearchDto.java
@@ -6,19 +6,19 @@ import org.pojomatic.annotations.AutoProperty;
 @AutoProperty
 public class SearchDto {
 
-	private String searchResultDbId;
+	private String searchResultsDbId;
 
-	public SearchDto(final String searchResultDbId) {
+	public SearchDto(final String searchResultsDbId) {
 		super();
-		this.searchResultDbId = searchResultDbId;
+		this.searchResultsDbId = searchResultsDbId;
 	}
 
-	public String getSearchResultDbId() {
-		return this.searchResultDbId;
+	public String getSearchResultsDbId() {
+		return this.searchResultsDbId;
 	}
 
-	public void setSearchResultDbId(final String searchResultDbId) {
-		this.searchResultDbId = searchResultDbId;
+	public void setSearchResultsDbId(final String searchResultsDbId) {
+		this.searchResultsDbId = searchResultsDbId;
 	}
 
 	@Override

--- a/src/test/java/org/ibp/api/brapi/v2/germplasm/GermplasmResourceBrapiTest.java
+++ b/src/test/java/org/ibp/api/brapi/v2/germplasm/GermplasmResourceBrapiTest.java
@@ -360,7 +360,7 @@ public class GermplasmResourceBrapiTest extends ApiUnitTestBase {
 				.locale(Locale.getDefault()))
 			.andExpect(MockMvcResultMatchers.status().isOk())
 			.andDo(MockMvcResultHandlers.print())
-			.andExpect(MockMvcResultMatchers.jsonPath("$.result.searchResultDbId", Matchers.is(String.valueOf(searchResultsDbId))));
+			.andExpect(MockMvcResultMatchers.jsonPath("$.result.searchResultsDbId", Matchers.is(String.valueOf(searchResultsDbId))));
 
 	}
 


### PR DESCRIPTION
- use storageTypes for v2 and typeOfGermplasmStorageCode for v1, assign empty list as default value
- change to searchResultsDbId (previously missing s) in SearchDto and update all references (including js/ts usage)