### PR TITLE
IBP-5170: Remove PreAuthorize for GET tree and GET variables services

### DIFF
--- a/src/main/java/org/ibp/api/rest/germplasmlist/GermplasmListResourceGroup.java
+++ b/src/main/java/org/ibp/api/rest/germplasmlist/GermplasmListResourceGroup.java
@@ -78,7 +78,6 @@ public class GermplasmListResourceGroup {
 	private ReorderEntriesLock reorderEntriesLock;
 
 	@ApiOperation(value = "Get germplasm lists given a tree parent node folder", notes = "Get germplasm lists given a tree parent node folder")
-	@PreAuthorize("hasAnyAuthority('ADMIN', 'GERMPLASM', 'MANAGE_GERMPLASM', 'SEARCH_GERMPLASM')" + PermissionsEnum.HAS_INVENTORY_VIEW)
 	@RequestMapping(value = "/crops/{crop}/germplasm-lists/tree", method = RequestMethod.GET)
 	@ResponseBody
 	public ResponseEntity<List<TreeNode>> getGermplasmListByParentFolderId(
@@ -261,7 +260,6 @@ public class GermplasmListResourceGroup {
 	}
 
 	@ApiOperation(value = "Get tree of expanded germplasm list folders last used by user", notes = "Get tree of expanded germplasm list folders last used by user")
-	@PreAuthorize("hasAnyAuthority('ADMIN', 'GERMPLASM', 'MANAGE_GERMPLASM', 'SEARCH_GERMPLASM')" + PermissionsEnum.HAS_INVENTORY_VIEW)
 	@RequestMapping(value = "/crops/{crop}/germplasm-lists/tree-state", method = RequestMethod.GET)
 	@ResponseBody
 	public ResponseEntity<List<TreeNode>> getUserTreeState(
@@ -272,7 +270,6 @@ public class GermplasmListResourceGroup {
 	}
 
 	@ApiOperation(value = "Save hierarchy of germplasm list folders last used by user", notes = "Save hierarchy of germplasm list folders last used by user")
-	@PreAuthorize("hasAnyAuthority('ADMIN', 'GERMPLASM', 'MANAGE_GERMPLASM', 'SEARCH_GERMPLASM')" + PermissionsEnum.HAS_INVENTORY_VIEW)
 	@RequestMapping(value = "/crops/{crop}/germplasm-lists/tree-state", method = RequestMethod.POST)
 	@ResponseBody
 	public ResponseEntity<Void> saveUserTreeState(

--- a/src/main/java/org/ibp/api/rest/ontology/VariableResource.java
+++ b/src/main/java/org/ibp/api/rest/ontology/VariableResource.java
@@ -46,9 +46,6 @@ public class VariableResource {
 	@ApiOperation(value = "Get Variable", notes = "Get Variable By Id")
 	@RequestMapping(value = "/{cropname}/variables/{id}", method = RequestMethod.GET)
 	@ResponseBody
-	@PreAuthorize("hasAnyAuthority('ADMIN','CROP_MANAGEMENT','MANAGE_ONTOLOGIES')"
-		+ PermissionsEnum.HAS_MODIFY_ATTRIBUTES
-		+ PermissionsEnum.HAS_MANAGE_FILES)
 	public ResponseEntity<VariableDetails> getVariableById(@PathVariable final String cropname,
 			@RequestParam final String programUUID, @PathVariable final String id) {
 		return new ResponseEntity<>(this.variableService.getVariableById(cropname, programUUID, id), HttpStatus.OK);
@@ -93,9 +90,6 @@ public class VariableResource {
 	}
 
 	@ApiOperation(value = "All variables using given filter", notes = "Gets all variables using filter")
-	@PreAuthorize("hasAnyAuthority('ADMIN','STUDIES','MANAGE_STUDIES', 'MANAGE_ONTOLOGIES', 'CROP_MANAGEMENT')"
-		+ PermissionsEnum.HAS_MODIFY_ATTRIBUTES
-		+ PermissionsEnum.HAS_MANAGE_FILES)
 	@RequestMapping(value = "/{cropname}/variables/filter", method = RequestMethod.GET)
 	@ResponseBody
 	public ResponseEntity<List<VariableDetails>> listAllVariablesUsingFilter(

--- a/src/main/java/org/ibp/api/rest/study/StudyResource.java
+++ b/src/main/java/org/ibp/api/rest/study/StudyResource.java
@@ -76,7 +76,6 @@ public class StudyResource {
 
 	@ApiOperation(value = "Get the study tree")
 	@RequestMapping(value = "/{cropName}/studies/tree", method = RequestMethod.GET)
-	@PreAuthorize("hasAnyAuthority('ADMIN','STUDIES','MANAGE_STUDIES')" + PermissionsEnum.HAS_INVENTORY_VIEW)
 	@ResponseBody
 	public ResponseEntity<List<TreeNode>> getStudyTree(final @PathVariable String cropName,
 		@ApiParam("The program UUID") @RequestParam(required = false) final String programUUID,


### PR DESCRIPTION
Relates to: IBP-5011, IBP-5145

Some improvements can be made by making some apis accessible to
logged-in users regardless of permissions. These are GET endpoints
needed from different modules:

validate/map variables for import list:
- filter variables
- get variable by id

Save list:
- get germplasm list tree
- save tree-state

For consistency, we remove PreAuthorize also from get /studies/tree