### PR TITLE
IBP-5359: Add login path information in BMSAPI auth expired alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ BMSAPI ships with a user interface that allows easy exploration and interaction 
 
 Like in the case of direct access (e.g. the cURL examples in previous section) access to BMSAPI methods using this Swagger UI requires the user to first authenticate by logging into the BMS deployed on **the same server** and **in the same browser window/tab**. 
 
-If you access the Swagger UI  without login, an alert message will be shown saying **Authentication has expired. Please login to Workbench again, then refresh this page."**. Upon "OK"ing this alert message you will notice that you can still see the API listings and "Try it out!" button etc. under each resource, but upon invoking any API method by clocking the "Try it out!" button, authentication error response will be returned which looks like:
+If you access the Swagger UI  without login, an alert message will be shown saying that the authentication has expired. Upon "OK"ing this alert message you will notice that you can still see the API listings and "Try it out!" button etc. under each resource, but upon invoking any API method by clocking the "Try it out!" button, authentication error response will be returned which looks like:
 
 ```
 {
@@ -97,15 +97,6 @@ If you access the Swagger UI  without login, an alert message will be shown sayi
 ```
 
 So, go to the usual BMS login page **of the same server deployment** at `http://<server.host>:<server.port>/ibpworkbench/controller/auth/login/` **in the same browser window/tab** and login as a valid BMS user first. Once successfully logged into BMS, reload the Swagger UI home page `http://<server.host>:<server.port>/bmsapi/` in the same browser window (different tab is fine, but must be same browser window). You should then no longer see the alert message regarding authentication. The Swagger UI now detects that you are authenticated on same server as a valid user. Now invoking the API methods using the "Try it out!" button, you should expect to see appropriate data response.
-
-**EXAMPLE**
-
-Leafnode development team's nightly deploy of the BMSAPI can be seen at: http://api.leafnode.io:10081/bmsapi/. As explained above, you will see  **Authentication has expired. Please login to Workbench again, then refresh this page."** alert message because you are not yet logged in. You can see the API resources and method listings etc. but trying to invoke any of the methods using the "Try it out!" button, you will see HTTP 401, Unauthorized, Access Denied response as shown above.
-
-To successfully invoke the operations as an authenticated user, you need to first login as that user at http://api.leafnode.io:10081/ibpworkbench/controller/auth/login, then reload http://api.leafnode.io:10081/bmsapi/ in the same browser window. You should now be able to see actual data responses based on what the logged in user has access to.
-
-**Please note** that http://api.leafnode.io:10081/bmsapi/ was shown here purely as an example to demonstrate the use of BMSAPI Swagger user interface. It is not intended to be used for client demos or actual development against it. Because it is a development team's nightly deploy, it will be restarted/redeployed frequently without any notice. You are welcome to play around with it while it is up :)
-
  
 For Code Contributing Developers
 ================================

--- a/src/main/webapp/WEB-INF/html/index.html
+++ b/src/main/webapp/WEB-INF/html/index.html
@@ -39,17 +39,16 @@
 
 		// Setup required for BMS authentication.
 		function addApiKeyAuthorization() {
+			const loginPath = "/ibpworkbench/controller/auth/login";
+
 			var authToken = localStorage.getItem("bms.xAuthToken");
 			if (authToken) {
 				var authTokenJSON = JSON.parse(authToken);
 				if (!authTokenJSON.expires || authTokenJSON.expires <= new Date().getTime()) {
-					alert("Authentication has expired. Please login to Workbench again, then refresh this page.");
+					alert(`Authentication has expired. Please login to BMS again (${loginPath}), then refresh this page.`);
 				}
 			} else {
-				// Swagger front-end is not part of product so we as such do not expect users to see this screen.
-				// This should happen only in cases where BMSAPI swagger front-end is loaded directly
-				//  which should only happen for demo/development environments hence is fair enough to require being logged in to Workbench first.
-				alert("You don't seem to have logged in. Please login to Workbench first, then refresh this page.");
+				alert(`You don't seem to have logged in. Please login to BMS first (${loginPath}), then refresh this page.`);
 			}
 		}
 


### PR DESCRIPTION
- Remove comment about swagger being only used for development, as we
adopt BrAPI more and more clients start to rely on BMSAPI swagger for
testing and production-related concerns.
- Keep approach of not redirecting automatically, so the spec can be
inspected even by non-authenticated users
- Remove example in README.md about legacy leafnode server