### PR TITLE
IBP-5411 fix intermittently failing tests

### DIFF
--- a/src/test/java/org/ibp/api/rest/labelprinting/GermplasmLabelPrintingTest.java
+++ b/src/test/java/org/ibp/api/rest/labelprinting/GermplasmLabelPrintingTest.java
@@ -116,6 +116,7 @@ public class GermplasmLabelPrintingTest {
 	public void testGetOriginResourceMetadata() {
 		final OriginResourceMetadata originResourceMetadata =
 			this.germplasmLabelPrinting.getOriginResourceMetadata(this.labelsInfoInput, PROGRAM_UUID);
+		Assert.assertTrue(MapUtils.isEmpty(originResourceMetadata.getMetadata()));
 		Assert.assertTrue(originResourceMetadata.getDefaultFileName().startsWith(GermplasmLabelPrinting.ORIG_FINAL_NAME));
 	}
 

--- a/src/test/java/org/ibp/api/rest/labelprinting/GermplasmLabelPrintingTest.java
+++ b/src/test/java/org/ibp/api/rest/labelprinting/GermplasmLabelPrintingTest.java
@@ -116,10 +116,7 @@ public class GermplasmLabelPrintingTest {
 	public void testGetOriginResourceMetadata() {
 		final OriginResourceMetadata originResourceMetadata =
 			this.germplasmLabelPrinting.getOriginResourceMetadata(this.labelsInfoInput, PROGRAM_UUID);
-		Assert.assertTrue(MapUtils.isEmpty(originResourceMetadata.getMetadata()));
-		Assert.assertEquals(
-			FileUtils.cleanFileName(FileNameGenerator.generateFileName(GermplasmLabelPrinting.ORIG_FINAL_NAME)),
-			originResourceMetadata.getDefaultFileName());
+		Assert.assertTrue(originResourceMetadata.getDefaultFileName().startsWith(GermplasmLabelPrinting.ORIG_FINAL_NAME));
 	}
 
 	@Test


### PR DESCRIPTION
Only check the start of the file name. Timestamp causes the intermittent fails.